### PR TITLE
fix: enforce semantic commits in Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended"
   ],
+  "semanticCommits": "enabled",
   "enabledManagers": [
     "github-actions"
   ],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -13,7 +13,7 @@
         "github-actions"
       ],
       "matchDepTypes": [
-        "github-actions"
+        "action"
       ],
       "matchFileNames": [
         ".github/workflows/**"


### PR DESCRIPTION
Renovate v43.104.0 changed its semantic commit auto-detector. Fix: explicitly set `"semanticCommits": "enabled"` instead of relying on auto-detection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled semantic commit messages for automated dependency updates.
  * Adjusted dependency update targeting so scheduled updates and grouping apply to action-type dependencies.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->