### PR TITLE
fix: enforce node signatures count equals operators count in validate…

### DIFF
--- a/src/verification/common.ts
+++ b/src/verification/common.ts
@@ -451,8 +451,9 @@ export const verifyNodeSignatures = (clusterLock: ClusterLock): boolean => {
   const nodeSignatures = clusterLock.node_signatures;
 
   if (
+    !nodeSignatures ||
     (nodeSignatures as string[]).length !==
-    clusterLock.cluster_definition.operators.length
+      clusterLock.cluster_definition.operators.length
   ) {
     return false;
   }

--- a/src/verification/common.ts
+++ b/src/verification/common.ts
@@ -452,23 +452,22 @@ export const verifyNodeSignatures = (clusterLock: ClusterLock): boolean => {
 
   if (
     !nodeSignatures ||
-    (nodeSignatures as string[]).length !==
-      clusterLock.cluster_definition.operators.length
+    nodeSignatures.length !== clusterLock.cluster_definition.operators.length
   ) {
     return false;
   }
 
   const lockHashWithout0x = hexWithout0x(clusterLock.lock_hash);
   // node(ENR) signatures
-  for (let i = 0; i < (nodeSignatures as string[]).length; i++) {
+  for (let i = 0; i < nodeSignatures.length; i++) {
     const publicKeyBytes = ENR.decodeTxt(
       clusterLock.cluster_definition.operators[i].enr as string,
     ).publicKey;
     const pubkey = Buffer.from(publicKeyBytes).toString('hex');
 
     const ENRsignature = {
-      r: (nodeSignatures as string[])[i].slice(2, 66),
-      s: (nodeSignatures as string[])[i].slice(66, 130),
+      r: nodeSignatures[i].slice(2, 66),
+      s: nodeSignatures[i].slice(66, 130),
     };
 
     const nodeSignatureVerification = ec

--- a/src/verification/common.ts
+++ b/src/verification/common.ts
@@ -450,6 +450,13 @@ export const verifyNodeSignatures = (clusterLock: ClusterLock): boolean => {
   const ec = new elliptic.ec('secp256k1');
   const nodeSignatures = clusterLock.node_signatures;
 
+  if (
+    (nodeSignatures as string[]).length !==
+    clusterLock.cluster_definition.operators.length
+  ) {
+    return false;
+  }
+
   const lockHashWithout0x = hexWithout0x(clusterLock.lock_hash);
   // node(ENR) signatures
   for (let i = 0; i < (nodeSignatures as string[]).length; i++) {


### PR DESCRIPTION
…ClusterLock

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved node signature validation to verify data consistency before processing, preventing errors from mismatched signature counts and avoiding unnecessary verification steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->