### PR TITLE
fix: use Node 22.x for @chainsafe/blst compatibility

### DIFF
--- a/.github/workflows/build-deploy-obol-sdk.yml
+++ b/.github/workflows/build-deploy-obol-sdk.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: '24.x'
+          node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
           scope: '@obolnetwork'
 

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: 24.x
+          node-version: 22.x
           cache: npm
 
       - name: Install dependancies


### PR DESCRIPTION
## Summary

- Downgrade Node from 24.x to 22.x in both `build-deploy-obol-sdk.yml` and `release-pr.yml`

`@chainsafe/blst` native bindings fail to compile on Node 24 due to V8 API breaking changes (`.Holder()`, `.SetAccessor()` removed). Node 22.x LTS still satisfies the OIDC trusted publisher requirement (npm CLI >= 11.5.1 ships with Node >= 22.14).

Follows up on #190.