### PR TITLE
fix: use Node 24 with --ignore-scripts for OIDC publishing

### DIFF
--- a/.github/workflows/build-deploy-obol-sdk.yml
+++ b/.github/workflows/build-deploy-obol-sdk.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: '22.x'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
           scope: '@obolnetwork'
 
@@ -58,7 +58,7 @@ jobs:
           prerelease: ${{ contains(steps.package-version.outputs.current-version, '-rc.') }}
 
       ############# NPM RELEASE ##############
-      - run: yarn install --frozen-lockfile
+      - run: yarn install --frozen-lockfile --ignore-scripts
       - run: yarn run build
       - run: yarn run generate-typedoc
       - name: Publish to NPM

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -28,7 +28,8 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '24'
-          cache: npm
+          cache: yarn
+          cache-dependency-path: yarn.lock
 
       - name: Install dependancies
         run: yarn install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -27,11 +27,11 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: 22.x
+          node-version: '24'
           cache: npm
 
       - name: Install dependancies
-        run: yarn install --frozen-lockfile
+        run: yarn install --frozen-lockfile --ignore-scripts
 
       - name: Prepare release
         env:


### PR DESCRIPTION
## Summary

- Upgrade Node from 22.x to 24 in both `build-deploy-obol-sdk.yml` and `release-pr.yml`
- Node 24 ships with npm 11.x which supports OIDC trusted publishers natively (Node 22 ships npm 10.x which doesn't)
- Add `--ignore-scripts` to `yarn install` to skip `@chainsafe/blst` native compilation that fails on Node 24 V8 changes — not needed for tsup/esbuild bundling or release-it

## Context

Follows up on #190 and #191. Node 22 required a hacky npm bootstrap to get npm 11, which broke. Node 24 is the clean path as recommended by the [npm trusted publishers docs](https://docs.npmjs.com/trusted-publishers#github-actions-configuration).

## Prerequisites

Configure the trusted publisher on npmjs.com for `@obolnetwork/obol-sdk`:

| Field | Value |
|-------|-------|
| Organization or user | `ObolNetwork` |
| Repository | `obol-sdk` |
| Workflow filename | `build-deploy-obol-sdk.yml` |
| Environment name | *(blank)* |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build and release workflow infrastructure to improve system stability and ensure consistent behavior during dependency installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->