### PR TITLE
perf: parallelize share-binding via worker_threads

### DIFF
--- a/PARALLEL_VALIDATION_PLAN.md
+++ b/PARALLEL_VALIDATION_PLAN.md
@@ -118,6 +118,63 @@ a multi-day refactor.
    bench (`test/perf/parallelBench.mjs`) is the only thing that exercises
    workers. If the worker breaks, CI stays green.
 
+## Decision record: `require()` in `parallelPool.ts`
+
+`parallelPool.ts` intentionally uses guarded `require('node:*')` calls
+inside `try/catch` (with narrow eslint disables) instead of top-level
+`import` for `worker_threads`, `os`, `path`, and `fs`.
+
+### Why this works
+
+The current pattern preserves three required behaviors:
+
+1. **Lazy runtime load** - Node-only modules are resolved only when needed.
+2. **No static Node import pull-in for browser bundles** - avoids bundler
+   statically binding `node:*` in browser output.
+3. **Synchronous probing** - callsites stay sync/cheap for environment checks.
+
+Observed runtime behavior:
+
+| Build target | `require('node:worker_threads')` result | Outcome |
+|---|---|---|
+| CJS Node | Loads real module | Parallel path enabled ✅ |
+| ESM Node | tsup dynamic-require shim throws; caught | Sync fallback |
+| Browser | shim/unsupported require throws; caught | Sync fallback |
+
+So the runtime behavior is correct across supported targets.
+
+### Why this is not ideal stylistically
+
+- `require()` in modern TS source is less idiomatic than `import()`.
+- Each call needs local eslint disables (`no-require-imports` /
+  `no-var-requires`), which adds review noise.
+- It depends on current tsup ESM dynamic-require behavior (throw + catch).
+
+### Preferred cleanup path (future)
+
+Refactor lazy loaders to dynamic import:
+
+```ts
+async function loadWorkerThreads(): Promise<WorkerThreads | null> {
+  try {
+    return await import('node:worker_threads');
+  } catch {
+    return null;
+  }
+}
+```
+
+Trade-offs of this refactor:
+
+- **Pros:** idiomatic ESM/CJS-compatible runtime loading; no eslint disables.
+- **Cons:** loader/cache flow becomes async (`Promise<Module>` cache), so
+  callers need small plumbing changes.
+- **Build note:** browser output still needs `node:*` treated as external in
+  bundling config so runtime `import()` can fail safely and be caught.
+
+Status today: keep `require()` because it is functionally correct, CI/bench are
+green, and it keeps the current sync fallback behavior simple.
+
 ## Out of scope (explicit followups)
 
 - Web Workers for browser parallelization (requires Next.js bundler work)

--- a/PARALLEL_VALIDATION_PLAN.md
+++ b/PARALLEL_VALIDATION_PLAN.md
@@ -24,7 +24,7 @@ of any reasonable HTTP timeout.
 | Build target | Worker path | Outcome | Why |
 |---|---|---|---|
 | **CJS Node** (obol-api / NestJS) | `dist/cjs/src/verification/lockWorker.js` | **Parallel** ✅ | `__dirname` resolves; `worker_threads` available; everything wires up |
-| ESM Node | none | Sync fallback | tsup ESM build has no `__dirname`; no `import.meta.url` plumbing in place. Documented limitation. |
+| ESM Node | none | Sync fallback | See "Why ESM is sync" below. |
 | Browser (dv-launchpad / Next.js) | none (worker not emitted) | Sync fallback | Browser has no `worker_threads`; would need Web Workers + Next.js bundler config. Out of scope. |
 | Source-mode (jest, tsx, ts-node) | resolves but file missing | Sync fallback | The `.js` file isn't there pre-build; `fs.existsSync` check returns false. |
 | Small lock (`< MIN_PARALLEL_VALIDATORS`) | available | Sync fallback | Worker spin-up dominates for small inputs (~30-100ms each). |
@@ -68,6 +68,36 @@ sync, and that's both fast enough and intentional.
 
 No new public surface. `validateClusterLock(lock, safeRpcUrl?)` keeps the
 same signature; parallelization is transparent.
+
+## Why ESM is sync (and not "just shim `__dirname` in tsup")
+
+The obvious-looking fix — adding a tsup `banner` that defines `__dirname`
+via `import.meta.url` for the ESM build — was tried and **does not work**.
+Two compounding problems:
+
+1. `parallelPool.ts` uses `require('node:path')` / `require('node:fs')`
+   inside `getWorkerPath()` to keep these imports out of the browser
+   bundle. tsup polyfills `require()` in ESM output to throw
+   `"Dynamic require of "path" is not supported"`. So even with the
+   `__dirname` shim, the function crashes on the first `require()`.
+2. tsup splits `parallelPool.ts`'s implementation into a shared chunk
+   (`dist/esm/src/chunk-XXXX.js`); the entry `parallelPool.js` is just a
+   re-export. The chunk's `__dirname` resolves to `dist/esm/src/`, not
+   `dist/esm/src/verification/`, so the worker file lookup misses and
+   falls back to sync.
+
+A real ESM fix needs either:
+- Refactoring `parallelPool.ts` to use top-level `import` for `node:path`
+  and friends (which then either breaks browser builds or needs
+  per-build entry shimming),
+- Disabling tsup `splitting` for the ESM build (loses code-sharing,
+  bigger output),
+- Or using `import.meta.url` directly in source, which is ESM-only
+  syntax that breaks the CJS build unless gated behind a runtime trick.
+
+None of these are "small". The CJS path covers obol-api (the only known
+heavy consumer), so this is left as a documented limitation rather than
+a multi-day refactor.
 
 ## Caveats / fragility
 

--- a/PARALLEL_VALIDATION_PLAN.md
+++ b/PARALLEL_VALIDATION_PLAN.md
@@ -1,0 +1,85 @@
+# Parallel Lock Validation Plan
+
+## Problem
+
+`validateClusterLock` is CPU-bound and single-threaded. For large locks (100+ validators) on
+pure-JS BLS, total time is in the 15-30s+ range — long enough that obol-api's HTTP handlers
+time out before validation completes.
+
+`Promise.all` does not help here: BLS in `@noble/curves` is synchronous CPU work, so awaiting
+multiple promises serializes them. Real parallelism requires worker threads.
+
+## Bottleneck breakdown (estimated, 500 validators, 4-of-6)
+
+| Phase | Cost | Parallelizable |
+|---|---|---|
+| Per-validator Lagrange + extra-share check | ~10-20s (10k G1 muls) | Yes — embarrassingly parallel by validator |
+| `blsVerifyMultiple` (2k deposit+builder pairings, batched) | ~5-10s | Yes — split into per-worker batches |
+| `blsVerifyAggregate` (single aggregate sig over lock_hash) | <100ms | No (single op, fast) |
+| `verifyNodeSignatures` (N secp256k1) | <50ms | No (small, fast) |
+
+So we parallelize the per-validator block + split the batch pairing across workers. Aggregate
+sig + node sigs stay on the main thread.
+
+## Approach
+
+1. **Node.js**: use `worker_threads`. Pool of `min(os.cpus().length, ceil(V/25), 8)` workers,
+   only when `validators.length >= 50` (otherwise the spin-up cost wins).
+2. **Browser**: out of scope for first cut. Falls back to current sync path. Web Workers
+   would need separate bundler config (Next.js url loader etc.) — followup.
+3. **Restricted environments** (no `worker_threads`, no `Worker`): falls back to sync.
+
+## Worker contract
+
+Input: `{ validators, context }` where context has the per-version data the worker needs:
+operatorCount, threshold, fork_version, withdrawal_addresses, fee_recipient_addresses,
+compounding flag, version tag.
+
+Per-validator the worker does:
+- Lagrange reconstruction on first `threshold` shares → must equal `distributed_public_key`
+- `blsVerifyExtraShares` for shares beyond threshold
+- Builds deposit-data + builder-registration signing roots
+- Aggregates per-chunk deposit + builder signatures and runs `blsVerifyMultiple` on its own slice
+
+Output: `{ ok: boolean, pubShares: Uint8Array[][] }` — main thread only needs the per-validator
+public shares to feed into the global aggregate-sig check.
+
+## Files
+
+- `src/verification/lockWorker.ts` — worker entry point. Imports verification helpers, runs the
+  per-chunk work. Bundled as a separate tsup entry so it lands in
+  `dist/cjs/src/verification/lockWorker.js` and the ESM equivalent.
+- `src/verification/parallelPool.ts` — pool abstraction. Detects `worker_threads`, manages
+  worker lifecycle, exposes `runParallel(validators, context)` that returns the merged result.
+- `src/verification/v1.6.0.ts`, `v1.7.0.ts`, `v1.8.0.ts` — `verifyDV` functions call into the
+  pool when the pool is available + `validators.length >= MIN_PARALLEL_VALIDATORS`. Otherwise
+  the existing sync code path runs unchanged.
+- `tsup.config.ts` — second entry for the worker file in CJS + ESM Node builds. Browser build
+  excludes it.
+
+## Public API
+
+No new public surface. `validateClusterLock(lock, safeRpcUrl?)` keeps the same signature.
+Parallelization is transparent.
+
+## Testing
+
+- Unit tests still pass (sync fallback for the existing fixture sizes).
+- New benchmark in `test/perf/lockValidation.bench.ts` (excluded from `yarn test`):
+  - Generates a synthetic 500-validator lock (deterministic, seeded).
+  - Times sync vs parallel.
+  - Asserts both produce the same boolean.
+
+## Out of scope (followups)
+
+- Web Workers / browser parallel path.
+- Worker-internal MSM / multi-scalar mul (would need noble support or hand-rolled Pippenger).
+- Replacing pure-JS BLS with WASM blst on the server side (separate dep migration).
+
+## Risks
+
+- Worker file path resolution differs between CJS, ESM, and bundlers that re-bundle the SDK.
+  Plan: resolve via `__dirname` in CJS, `import.meta.url` in ESM. Document for downstream
+  bundlers — if it breaks, the pool falls back to sync.
+- Worker startup overhead (~30-100ms per worker). Mitigated by the `MIN_PARALLEL_VALIDATORS`
+  threshold and reuse-pool design (workers stay alive across calls if possible).

--- a/PARALLEL_VALIDATION_PLAN.md
+++ b/PARALLEL_VALIDATION_PLAN.md
@@ -113,10 +113,20 @@ a multi-day refactor.
    call processing hundreds of validators, this is amortized; for
    high-frequency repeated calls on small locks, sync is still chosen by
    the threshold.
-3. **No automated test for the parallel path.** Existing fixtures are
-   small enough to trip `MIN_PARALLEL_VALIDATORS=50` and run sync. The
-   bench (`test/perf/parallelBench.mjs`) is the only thing that exercises
-   workers. If the worker breaks, CI stays green.
+3. **No automated test for the actual worker path.** `test/verification/
+   parallelPool.spec.ts` exercises the public `verifySharesBinding` and
+   `verifyBatchParallel` API with 50-100 input batches — enough to trip
+   the parallel threshold — but jest runs from source so the built
+   `lockWorker.js` doesn't exist; `getWorkerPath()` returns `null` and
+   the tests transparently run the **sync fallback**. They catch:
+   - sync-fallback correctness regressions
+   - `WorkerInput` shape mismatches at compile time (now typed)
+   - API signature drift
+
+   They do **not** catch worker-thread-specific breakage (path
+   resolution, structured-clone issues, the worker entry crashing).
+   For that, run `node test/perf/parallelBench.mjs` after `yarn build` —
+   that is the only thing that exercises the real worker code today.
 
 ## Decision record: `require()` in `parallelPool.ts`
 
@@ -188,6 +198,6 @@ green, and it keeps the current sync fallback behavior simple.
 ```bash
 yarn install
 yarn build           # emits the three dist entries the pool needs
-yarn test            # 131 unit tests, all sync (small fixtures)
-node test/perf/parallelBench.mjs   # confirms speedup on a real machine
+yarn test            # 141 unit tests, all sync (pool tests hit fallback)
+node test/perf/parallelBench.mjs   # confirms parallel speedup on dist
 ```

--- a/PARALLEL_VALIDATION_PLAN.md
+++ b/PARALLEL_VALIDATION_PLAN.md
@@ -2,84 +2,105 @@
 
 ## Problem
 
-`validateClusterLock` is CPU-bound and single-threaded. For large locks (100+ validators) on
-pure-JS BLS, total time is in the 15-30s+ range — long enough that obol-api's HTTP handlers
-time out before validation completes.
+`validateClusterLock` is CPU-bound and single-threaded on pure-JS BLS. Large
+locks (100+ validators) take 15-30s+ — long enough that obol-api's HTTP
+handler times out before validation completes. `Promise.all` does not help,
+because BLS in `@noble/curves` is synchronous CPU work; awaiting promises
+serializes them. Real parallelism requires worker threads.
 
-`Promise.all` does not help here: BLS in `@noble/curves` is synchronous CPU work, so awaiting
-multiple promises serializes them. Real parallelism requires worker threads.
+## Bottleneck (measured on 4 cores, see `test/perf/parallelBench.mjs`)
 
-## Bottleneck breakdown (estimated, 500 validators, 4-of-6)
+| Phase | N=500 sync | N=500 parallel | Speedup |
+|---|---|---|---|
+| Share-binding (Lagrange + extras) | ~9.0s | ~2.2s | **4.0×** |
+| Batch BLS verify (deposit+builder) | ~11.3s | ~3.7s | **3.0×** |
+| Aggregate sig + node sigs | <200ms | (not parallelized) | — |
 
-| Phase | Cost | Parallelizable |
-|---|---|---|
-| Per-validator Lagrange + extra-share check | ~10-20s (10k G1 muls) | Yes — embarrassingly parallel by validator |
-| `blsVerifyMultiple` (2k deposit+builder pairings, batched) | ~5-10s | Yes — split into per-worker batches |
-| `blsVerifyAggregate` (single aggregate sig over lock_hash) | <100ms | No (single op, fast) |
-| `verifyNodeSignatures` (N secp256k1) | <50ms | No (small, fast) |
+End-to-end on a 500-validator lock: **~20s sync → ~6s parallel**, well clear
+of any reasonable HTTP timeout.
 
-So we parallelize the per-validator block + split the batch pairing across workers. Aggregate
-sig + node sigs stay on the main thread.
+## Where it actually runs (build x outcome matrix)
 
-## Approach
+| Build target | Worker path | Outcome | Why |
+|---|---|---|---|
+| **CJS Node** (obol-api / NestJS) | `dist/cjs/src/verification/lockWorker.js` | **Parallel** ✅ | `__dirname` resolves; `worker_threads` available; everything wires up |
+| ESM Node | none | Sync fallback | tsup ESM build has no `__dirname`; no `import.meta.url` plumbing in place. Documented limitation. |
+| Browser (dv-launchpad / Next.js) | none (worker not emitted) | Sync fallback | Browser has no `worker_threads`; would need Web Workers + Next.js bundler config. Out of scope. |
+| Source-mode (jest, tsx, ts-node) | resolves but file missing | Sync fallback | The `.js` file isn't there pre-build; `fs.existsSync` check returns false. |
+| Small lock (`< MIN_PARALLEL_VALIDATORS`) | available | Sync fallback | Worker spin-up dominates for small inputs (~30-100ms each). |
 
-1. **Node.js**: use `worker_threads`. Pool of `min(os.cpus().length, ceil(V/25), 8)` workers,
-   only when `validators.length >= 50` (otherwise the spin-up cost wins).
-2. **Browser**: out of scope for first cut. Falls back to current sync path. Web Workers
-   would need separate bundler config (Next.js url loader etc.) — followup.
-3. **Restricted environments** (no `worker_threads`, no `Worker`): falls back to sync.
+**Bottom line:** the **canonical DKG publish flow is fully covered**:
 
-## Worker contract
+```
+charon (dkg) -> obol-api (NestJS / CJS / Node 24) -> obol-sdk validateClusterLock (CJS dist)
+                                                       └─> parallel ✅
+```
 
-Input: `{ validators, context }` where context has the per-version data the worker needs:
-operatorCount, threshold, fork_version, withdrawal_addresses, fee_recipient_addresses,
-compounding flag, version tag.
+Every other path (browser SDK consumers, jest tests, small fixture locks) is
+sync, and that's both fast enough and intentional.
 
-Per-validator the worker does:
-- Lagrange reconstruction on first `threshold` shares → must equal `distributed_public_key`
-- `blsVerifyExtraShares` for shares beyond threshold
-- Builds deposit-data + builder-registration signing roots
-- Aggregates per-chunk deposit + builder signatures and runs `blsVerifyMultiple` on its own slice
+## Thresholds
 
-Output: `{ ok: boolean, pubShares: Uint8Array[][] }` — main thread only needs the per-validator
-public shares to feed into the global aggregate-sig check.
+- `MIN_PARALLEL_VALIDATORS = 50` — share-binding needs at least this many
+  validators before workers are worth spinning up.
+- `MIN_PARALLEL_BATCH_PAIRS = 100` — batch BLS verify threshold.
+- `MIN_VALIDATORS_PER_WORKER = 25`, `MIN_PAIRS_PER_WORKER = 50` — minimum
+  chunk size to keep workers busy enough to amortize startup.
+- `MAX_WORKERS = 8` — soft cap; effective parallelism also bounded by
+  `os.cpus().length`.
 
 ## Files
 
-- `src/verification/lockWorker.ts` — worker entry point. Imports verification helpers, runs the
-  per-chunk work. Bundled as a separate tsup entry so it lands in
-  `dist/cjs/src/verification/lockWorker.js` and the ESM equivalent.
-- `src/verification/parallelPool.ts` — pool abstraction. Detects `worker_threads`, manages
-  worker lifecycle, exposes `runParallel(validators, context)` that returns the merged result.
-- `src/verification/v1.6.0.ts`, `v1.7.0.ts`, `v1.8.0.ts` — `verifyDV` functions call into the
-  pool when the pool is available + `validators.length >= MIN_PARALLEL_VALIDATORS`. Otherwise
-  the existing sync code path runs unchanged.
-- `tsup.config.ts` — second entry for the worker file in CJS + ESM Node builds. Browser build
-  excludes it.
+- `src/verification/lockWorker.ts` — worker entry. One file, two modes
+  (`shareBinding`, `verifyBatch`) dispatched on `workerData.mode`.
+- `src/verification/parallelPool.ts` — pool abstraction. Exposes
+  `verifySharesBinding` and `verifyBatchParallel`. Each has a sync fallback
+  identical in shape to the parallel path.
+- `src/verification/v1.6.0.ts` / `v1.7.0.ts` / `v1.8.0.ts` — `verifyDV` is
+  structured as Phase 1 (cheap structural pre-checks: count, uniqueness)
+  then Phase 2 (parallel share-binding) then existing per-validator data
+  collection then parallel batch verify.
+- `tsup.config.ts` — three Node entries (`blsUtils`, `parallelPool`,
+  `lockWorker`) so they stay separate dist files. Browser build does not
+  include the worker entry.
 
 ## Public API
 
-No new public surface. `validateClusterLock(lock, safeRpcUrl?)` keeps the same signature.
-Parallelization is transparent.
+No new public surface. `validateClusterLock(lock, safeRpcUrl?)` keeps the
+same signature; parallelization is transparent.
 
-## Testing
+## Caveats / fragility
 
-- Unit tests still pass (sync fallback for the existing fixture sizes).
-- New benchmark in `test/perf/lockValidation.bench.ts` (excluded from `yarn test`):
-  - Generates a synthetic 500-validator lock (deterministic, seeded).
-  - Times sync vs parallel.
-  - Asserts both produce the same boolean.
+1. **Noble's `getPublicKey()` returns a Point object, not `Uint8Array`,**
+   even though the type declarations claim otherwise. We rely on this
+   internally; if a future noble version changes the return shape, the
+   `as any` cast in the bench (and any future callers) needs review.
+   `Point` instances do **not** survive `workerData` structured clone
+   (their class prototype is stripped). Always serialize via `.toBytes()`
+   before sending across the worker boundary.
+2. **No persistent worker pool.** Each `validateClusterLock` call spawns
+   workers fresh and pays ~30-100ms per worker startup. For a single
+   call processing hundreds of validators, this is amortized; for
+   high-frequency repeated calls on small locks, sync is still chosen by
+   the threshold.
+3. **No automated test for the parallel path.** Existing fixtures are
+   small enough to trip `MIN_PARALLEL_VALIDATORS=50` and run sync. The
+   bench (`test/perf/parallelBench.mjs`) is the only thing that exercises
+   workers. If the worker breaks, CI stays green.
 
-## Out of scope (followups)
+## Out of scope (explicit followups)
 
-- Web Workers / browser parallel path.
-- Worker-internal MSM / multi-scalar mul (would need noble support or hand-rolled Pippenger).
-- Replacing pure-JS BLS with WASM blst on the server side (separate dep migration).
+- Web Workers for browser parallelization (requires Next.js bundler work)
+- ESM Node parallelization (would need tsup banner injecting
+  `import.meta.url` into the pool)
+- Persistent worker pool with idle-timeout reuse
+- Parallelizing the aggregate-sig and node-sig checks (not bottlenecks)
 
-## Risks
+## How to verify locally
 
-- Worker file path resolution differs between CJS, ESM, and bundlers that re-bundle the SDK.
-  Plan: resolve via `__dirname` in CJS, `import.meta.url` in ESM. Document for downstream
-  bundlers — if it breaks, the pool falls back to sync.
-- Worker startup overhead (~30-100ms per worker). Mitigated by the `MIN_PARALLEL_VALIDATORS`
-  threshold and reuse-pool design (workers stay alive across calls if possible).
+```bash
+yarn install
+yarn build           # emits the three dist entries the pool needs
+yarn test            # 131 unit tests, all sync (small fixtures)
+node test/perf/parallelBench.mjs   # confirms speedup on a real machine
+```

--- a/src/blsUtils.ts
+++ b/src/blsUtils.ts
@@ -5,6 +5,24 @@ import { bls12_381 } from '@noble/curves/bls12-381.js';
 const { longSignatures: ls } = bls12_381;
 const ETH2_DST = 'BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_';
 
+export function blsSign(
+  secretKey: Uint8Array,
+  message: Uint8Array,
+): Uint8Array {
+  return ls.Signature.toBytes(ls.sign(ls.hash(message, ETH2_DST), secretKey)) as Uint8Array;
+}
+
+export function blsGetPublicKey(secretKey: Uint8Array): Uint8Array {
+  // getPublicKey returns a G1 Point object; call toBytes() to get the
+  // compressed 48-byte Uint8Array needed for transfer through workerData.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return (ls.getPublicKey(secretKey) as any).toBytes() as Uint8Array;
+}
+
+export function blsKeygen(seed: Uint8Array): Uint8Array {
+  return ls.keygen(seed).secretKey as Uint8Array;
+}
+
 export function blsVerify(
   pubkey: Uint8Array,
   message: Uint8Array,

--- a/src/blsUtils.ts
+++ b/src/blsUtils.ts
@@ -5,24 +5,6 @@ import { bls12_381 } from '@noble/curves/bls12-381.js';
 const { longSignatures: ls } = bls12_381;
 const ETH2_DST = 'BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_';
 
-export function blsSign(
-  secretKey: Uint8Array,
-  message: Uint8Array,
-): Uint8Array {
-  return ls.Signature.toBytes(ls.sign(ls.hash(message, ETH2_DST), secretKey)) as Uint8Array;
-}
-
-export function blsGetPublicKey(secretKey: Uint8Array): Uint8Array {
-  // getPublicKey returns a G1 Point object; call toBytes() to get the
-  // compressed 48-byte Uint8Array needed for transfer through workerData.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return (ls.getPublicKey(secretKey) as any).toBytes() as Uint8Array;
-}
-
-export function blsKeygen(seed: Uint8Array): Uint8Array {
-  return ls.keygen(seed).secretKey as Uint8Array;
-}
-
 export function blsVerify(
   pubkey: Uint8Array,
   message: Uint8Array,

--- a/src/verification/lockWorker.ts
+++ b/src/verification/lockWorker.ts
@@ -1,27 +1,37 @@
 // Worker entry point loaded by parallelPool via Node's worker_threads.
 //
-// Responsibility: verify the share-binding step (Lagrange + extra shares)
-// for a chunk of validators. This is the dominant CPU cost in
-// validateClusterLock (~75% on a 500-validator lock per blsBench.mjs).
+// Two modes (dispatched on workerData.mode):
+//   'shareBinding' — Lagrange + extra-share verification for a validator chunk.
+//   'verifyBatch'  — blsVerifyMultiple on a (pubkeys, messages, aggregateSig)
+//                    chunk of the deposit+builder batch.
 //
-// Returns simple boolean — the main thread re-runs other validation steps
-// itself; this worker only handles the expensive math.
+// Both modes return a simple boolean; main thread combines results.
 
 import { parentPort, workerData } from 'node:worker_threads';
 import { fromHexString } from '@chainsafe/ssz';
 import {
   blsRecoverDistributedPubkeyFromShares,
   blsVerifyExtraShares,
+  blsVerifyMultiple,
 } from '../blsUtils.js';
 
-interface WorkerInput {
-  // For each validator in the chunk: hex strings.
+interface ShareBindingInput {
+  mode: 'shareBinding';
   shares: string[][];
   distributedKeys: string[];
   threshold: number;
 }
 
-function verifyChunk(input: WorkerInput): boolean {
+interface VerifyBatchInput {
+  mode: 'verifyBatch';
+  pubkeys: Uint8Array[];
+  messages: Uint8Array[];
+  aggregateSignature: Uint8Array;
+}
+
+type WorkerInput = ShareBindingInput | VerifyBatchInput;
+
+function verifyShareBindingChunk(input: ShareBindingInput): boolean {
   const { shares, distributedKeys, threshold } = input;
   if (shares.length !== distributedKeys.length) return false;
 
@@ -35,15 +45,9 @@ function verifyChunk(input: WorkerInput): boolean {
     );
     if (!recovered) return false;
     if (recovered.length !== dkBytes.length) return false;
-    let equal = true;
     for (let j = 0; j < recovered.length; j++) {
-      if (recovered[j] !== dkBytes[j]) {
-        equal = false;
-        break;
-      }
+      if (recovered[j] !== dkBytes[j]) return false;
     }
-    if (!equal) return false;
-
     if (!blsVerifyExtraShares(sharesBytes, threshold, dkBytes)) {
       return false;
     }
@@ -51,10 +55,23 @@ function verifyChunk(input: WorkerInput): boolean {
   return true;
 }
 
+function verifyBatchChunk(input: VerifyBatchInput): boolean {
+  return blsVerifyMultiple(
+    input.pubkeys,
+    input.messages,
+    input.aggregateSignature,
+  );
+}
+
+function dispatch(input: WorkerInput): boolean {
+  if (input.mode === 'shareBinding') return verifyShareBindingChunk(input);
+  if (input.mode === 'verifyBatch') return verifyBatchChunk(input);
+  return false;
+}
+
 if (parentPort) {
   try {
-    const ok = verifyChunk(workerData as WorkerInput);
-    parentPort.postMessage(ok);
+    parentPort.postMessage(dispatch(workerData as WorkerInput));
   } catch {
     parentPort.postMessage(false);
   }

--- a/src/verification/lockWorker.ts
+++ b/src/verification/lockWorker.ts
@@ -1,0 +1,61 @@
+// Worker entry point loaded by parallelPool via Node's worker_threads.
+//
+// Responsibility: verify the share-binding step (Lagrange + extra shares)
+// for a chunk of validators. This is the dominant CPU cost in
+// validateClusterLock (~75% on a 500-validator lock per blsBench.mjs).
+//
+// Returns simple boolean — the main thread re-runs other validation steps
+// itself; this worker only handles the expensive math.
+
+import { parentPort, workerData } from 'node:worker_threads';
+import { fromHexString } from '@chainsafe/ssz';
+import {
+  blsRecoverDistributedPubkeyFromShares,
+  blsVerifyExtraShares,
+} from '../blsUtils.js';
+
+interface WorkerInput {
+  // For each validator in the chunk: hex strings.
+  shares: string[][];
+  distributedKeys: string[];
+  threshold: number;
+}
+
+function verifyChunk(input: WorkerInput): boolean {
+  const { shares, distributedKeys, threshold } = input;
+  if (shares.length !== distributedKeys.length) return false;
+
+  for (let i = 0; i < shares.length; i++) {
+    const sharesBytes = shares[i].map(s => fromHexString(s));
+    const dkBytes = fromHexString(distributedKeys[i]);
+
+    const recovered = blsRecoverDistributedPubkeyFromShares(
+      sharesBytes,
+      threshold,
+    );
+    if (!recovered) return false;
+    if (recovered.length !== dkBytes.length) return false;
+    let equal = true;
+    for (let j = 0; j < recovered.length; j++) {
+      if (recovered[j] !== dkBytes[j]) {
+        equal = false;
+        break;
+      }
+    }
+    if (!equal) return false;
+
+    if (!blsVerifyExtraShares(sharesBytes, threshold, dkBytes)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+if (parentPort) {
+  try {
+    const ok = verifyChunk(workerData as WorkerInput);
+    parentPort.postMessage(ok);
+  } catch {
+    parentPort.postMessage(false);
+  }
+}

--- a/src/verification/lockWorker.ts
+++ b/src/verification/lockWorker.ts
@@ -15,21 +15,21 @@ import {
   blsVerifyMultiple,
 } from '../blsUtils.js';
 
-interface ShareBindingInput {
+export interface ShareBindingInput {
   mode: 'shareBinding';
   shares: string[][];
   distributedKeys: string[];
   threshold: number;
 }
 
-interface VerifyBatchInput {
+export interface VerifyBatchInput {
   mode: 'verifyBatch';
   pubkeys: Uint8Array[];
   messages: Uint8Array[];
   aggregateSignature: Uint8Array;
 }
 
-type WorkerInput = ShareBindingInput | VerifyBatchInput;
+export type WorkerInput = ShareBindingInput | VerifyBatchInput;
 
 function verifyShareBindingChunk(input: ShareBindingInput): boolean {
   const { shares, distributedKeys, threshold } = input;

--- a/src/verification/parallelPool.ts
+++ b/src/verification/parallelPool.ts
@@ -19,6 +19,12 @@ import {
   blsVerifyExtraShares,
   blsVerifyMultiple,
 } from '../blsUtils.js';
+// Type-only imports — erased at compile time, so they don't pull node:*
+// modules into the browser bundle.
+import type * as WTNs from 'node:worker_threads';
+import type * as OsNs from 'node:os';
+import type * as PathNs from 'node:path';
+import type * as FsNs from 'node:fs';
 
 const MIN_PARALLEL_VALIDATORS = 50;
 const MIN_PARALLEL_BATCH_PAIRS = 100;
@@ -26,8 +32,8 @@ const MAX_WORKERS = 8;
 const MIN_VALIDATORS_PER_WORKER = 25;
 const MIN_PAIRS_PER_WORKER = 50;
 
-type WorkerThreads = typeof import('node:worker_threads');
-type NodeOs = typeof import('node:os');
+type WorkerThreads = typeof WTNs;
+type NodeOs = typeof OsNs;
 
 let workerThreadsCache: WorkerThreads | null | undefined;
 let osCache: NodeOs | null | undefined;
@@ -36,7 +42,7 @@ let workerPathCache: string | undefined;
 function loadWorkerThreads(): WorkerThreads | null {
   if (workerThreadsCache !== undefined) return workerThreadsCache;
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
     workerThreadsCache = require('node:worker_threads') as WorkerThreads;
   } catch {
     workerThreadsCache = null;
@@ -47,7 +53,7 @@ function loadWorkerThreads(): WorkerThreads | null {
 function loadOs(): NodeOs | null {
   if (osCache !== undefined) return osCache;
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
     osCache = require('node:os') as NodeOs;
   } catch {
     osCache = null;
@@ -61,14 +67,14 @@ function getWorkerPath(): string | undefined {
   // returns undefined and the caller falls back to sync. See plan for the
   // full coverage matrix.
   if (typeof __dirname === 'undefined') return undefined;
-  // eslint-disable-next-line @typescript-eslint/no-require-imports
-  const path = require('node:path') as typeof import('node:path');
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+  const path = require('node:path') as typeof PathNs;
   const candidate = path.join(__dirname, 'lockWorker.js');
   // Sanity check: running from source (tsx, ts-node, jest without a build)
   // also hits the CJS branch but the .js file isn't there yet.
   try {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const fs = require('node:fs') as typeof import('node:fs');
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+    const fs = require('node:fs') as typeof FsNs;
     if (!fs.existsSync(candidate)) return undefined;
   } catch {
     return undefined;
@@ -110,13 +116,13 @@ function verifySharesSync(
   return true;
 }
 
-function runWorker(
+async function runWorker(
   wt: WorkerThreads,
   workerFile: string,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   data: Record<string, any>,
 ): Promise<boolean> {
-  return new Promise(resolve => {
+  return await new Promise(resolve => {
     let settled = false;
     const finish = (result: boolean): void => {
       if (settled) return;
@@ -126,8 +132,12 @@ function runWorker(
       resolve(result);
     };
     const worker = new wt.Worker(workerFile, { workerData: data });
-    worker.once('message', (msg: unknown) => finish(msg === true));
-    worker.once('error', () => finish(false));
+    worker.once('message', (msg: unknown) => {
+      finish(msg === true);
+    });
+    worker.once('error', () => {
+      finish(false);
+    });
     worker.once('exit', code => {
       if (code !== 0) finish(false);
     });
@@ -164,13 +174,14 @@ export async function verifySharesBinding(
     MIN_VALIDATORS_PER_WORKER,
   );
 
-  const useParallel =
-    wt !== null &&
-    workerFile !== undefined &&
-    shares.length >= MIN_PARALLEL_VALIDATORS &&
-    numWorkers >= 2;
-
-  if (!useParallel) {
+  // Inline the guard so TS narrows wt/workerFile for the parallel path below
+  // (avoids non-null assertions).
+  if (
+    wt === null ||
+    workerFile === undefined ||
+    shares.length < MIN_PARALLEL_VALIDATORS ||
+    numWorkers < 2
+  ) {
     return verifySharesSync(shares, distributedKeys, threshold);
   }
 
@@ -178,8 +189,8 @@ export async function verifySharesBinding(
   const keyChunks = chunkArrays(distributedKeys, numWorkers);
 
   const results = await Promise.all(
-    shareChunks.map((chunk, i) =>
-      runWorker(wt!, workerFile!, {
+    shareChunks.map(async (chunk, i) =>
+      await runWorker(wt, workerFile, {
         mode: 'shareBinding',
         shares: chunk,
         distributedKeys: keyChunks[i],
@@ -213,13 +224,12 @@ export async function verifyBatchParallel(
     MIN_PAIRS_PER_WORKER,
   );
 
-  const useParallel =
-    wt !== null &&
-    workerFile !== undefined &&
-    pubkeys.length >= MIN_PARALLEL_BATCH_PAIRS &&
-    numWorkers >= 2;
-
-  if (!useParallel) {
+  if (
+    wt === null ||
+    workerFile === undefined ||
+    pubkeys.length < MIN_PARALLEL_BATCH_PAIRS ||
+    numWorkers < 2
+  ) {
     return blsVerifyMultiple(
       pubkeys,
       messages,
@@ -232,8 +242,8 @@ export async function verifyBatchParallel(
   const sigChunks = chunkArrays(signatures, numWorkers);
 
   const results = await Promise.all(
-    pkChunks.map((pks, i) =>
-      runWorker(wt!, workerFile!, {
+    pkChunks.map(async (pks, i) =>
+      await runWorker(wt, workerFile, {
         mode: 'verifyBatch',
         pubkeys: pks,
         messages: msgChunks[i],

--- a/src/verification/parallelPool.ts
+++ b/src/verification/parallelPool.ts
@@ -25,19 +25,25 @@ import type * as WTNs from 'node:worker_threads';
 import type * as OsNs from 'node:os';
 import type * as PathNs from 'node:path';
 import type * as FsNs from 'node:fs';
+import type { WorkerInput } from './lockWorker.js';
 
 const MIN_PARALLEL_VALIDATORS = 50;
 const MIN_PARALLEL_BATCH_PAIRS = 100;
 const MAX_WORKERS = 8;
 const MIN_VALIDATORS_PER_WORKER = 25;
 const MIN_PAIRS_PER_WORKER = 50;
+// Hard ceiling so a stuck worker can't leak past obol-api's HTTP timeout.
+// Biggest legitimate batch (~1000 pairs) finishes in ~3s on the bench; 60s
+// is conservative enough to never false-trip on real input.
+const WORKER_TIMEOUT_MS = 60_000;
 
 type WorkerThreads = typeof WTNs;
 type NodeOs = typeof OsNs;
 
 let workerThreadsCache: WorkerThreads | null | undefined;
 let osCache: NodeOs | null | undefined;
-let workerPathCache: string | undefined;
+// Tri-state: undefined = uncached, null = checked & unavailable, string = path.
+let workerPathCache: string | null | undefined;
 
 function loadWorkerThreads(): WorkerThreads | null {
   if (workerThreadsCache !== undefined) return workerThreadsCache;
@@ -61,26 +67,26 @@ function loadOs(): NodeOs | null {
   return osCache;
 }
 
-function getWorkerPath(): string | undefined {
-  if (workerPathCache) return workerPathCache;
+function getWorkerPath(): string | null {
+  if (workerPathCache !== undefined) return workerPathCache;
   // CJS only. In ESM and browser builds __dirname is undefined, so this
-  // returns undefined and the caller falls back to sync. See plan for the
+  // memoizes null and the caller falls back to sync. See plan for the
   // full coverage matrix.
-  if (typeof __dirname === 'undefined') return undefined;
+  if (typeof __dirname === 'undefined') return (workerPathCache = null);
   // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
   const path = require('node:path') as typeof PathNs;
   const candidate = path.join(__dirname, 'lockWorker.js');
   // Sanity check: running from source (tsx, ts-node, jest without a build)
-  // also hits the CJS branch but the .js file isn't there yet.
+  // also hits the CJS branch but the .js file isn't there yet. Without
+  // memoizing null we'd re-run existsSync on every call.
   try {
     // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
     const fs = require('node:fs') as typeof FsNs;
-    if (!fs.existsSync(candidate)) return undefined;
+    if (!fs.existsSync(candidate)) return (workerPathCache = null);
   } catch {
-    return undefined;
+    return (workerPathCache = null);
   }
-  workerPathCache = candidate;
-  return workerPathCache;
+  return (workerPathCache = candidate);
 }
 
 function chunkArrays<T>(arr: T[], n: number): T[][] {
@@ -119,19 +125,22 @@ function verifySharesSync(
 async function runWorker(
   wt: WorkerThreads,
   workerFile: string,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  data: Record<string, any>,
+  data: WorkerInput,
 ): Promise<boolean> {
   return await new Promise(resolve => {
     let settled = false;
+    const worker = new wt.Worker(workerFile, { workerData: data });
     const finish = (result: boolean): void => {
       if (settled) return;
       settled = true;
+      clearTimeout(timer);
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       worker.terminate();
       resolve(result);
     };
-    const worker = new wt.Worker(workerFile, { workerData: data });
+    const timer = setTimeout(() => {
+      finish(false);
+    }, WORKER_TIMEOUT_MS);
     worker.once('message', (msg: unknown) => {
       finish(msg === true);
     });
@@ -150,7 +159,7 @@ function poolSize(
 ): {
   numWorkers: number;
   wt: WorkerThreads | null;
-  workerFile: string | undefined;
+  workerFile: string | null;
 } {
   const wt = loadWorkerThreads();
   const os = loadOs();
@@ -181,7 +190,7 @@ export async function verifySharesBinding(
   // (avoids non-null assertions).
   if (
     wt === null ||
-    workerFile === undefined ||
+    workerFile === null ||
     shares.length < MIN_PARALLEL_VALIDATORS ||
     numWorkers < 2
   ) {
@@ -230,7 +239,7 @@ export async function verifyBatchParallel(
 
   if (
     wt === null ||
-    workerFile === undefined ||
+    workerFile === null ||
     pubkeys.length < MIN_PARALLEL_BATCH_PAIRS ||
     numWorkers < 2
   ) {

--- a/src/verification/parallelPool.ts
+++ b/src/verification/parallelPool.ts
@@ -1,14 +1,16 @@
-// Parallel share-binding verification via Node worker_threads.
+// Parallel BLS verification via Node worker_threads.
+//
+// IMPORTANT: only the CJS build actually runs in parallel. ESM Node and
+// browser bundles transparently fall back to sync. See the matrix in
+// PARALLEL_VALIDATION_PLAN.md. The main consumer flow (charon DKG ->
+// obol-api NestJS handler -> SDK CJS) is CJS, so it gets the speedup.
 //
 // Strategy:
-// - Detect worker_threads at runtime. Browser/restricted envs => sync fallback.
-// - Below MIN_PARALLEL_VALIDATORS, sync wins (worker spin-up dominates).
+// - Look up the worker file via __dirname (CJS only). If undefined or the
+//   file isn't where we expect (ESM, browser, source-mode tsx/jest), return
+//   undefined and fall back to sync.
+// - Below MIN_PARALLEL_* thresholds, sync wins (worker spin-up dominates).
 // - Spawn one worker per chunk, await all, collapse to a single boolean.
-//
-// We resolve the worker file path from the same directory as this module —
-// tsup emits `lockWorker.js` next to `parallelPool.js` in both CJS and ESM
-// Node builds. Browser build excludes the worker entry; bundlers that
-// re-bundle the SDK and break path resolution will hit the sync fallback.
 
 import { fromHexString } from '@chainsafe/ssz';
 import {
@@ -55,29 +57,15 @@ function loadOs(): NodeOs | null {
 
 function getWorkerPath(): string | undefined {
   if (workerPathCache) return workerPathCache;
-  let candidate: string | undefined;
-  if (typeof __dirname !== 'undefined') {
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const path = require('node:path') as typeof import('node:path');
-    candidate = path.join(__dirname, 'lockWorker.js');
-  } else {
-    // ESM: resolve via import.meta.url — set by build/runtime.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const meta = (globalThis as any).__OBOL_SDK_IMPORT_META__;
-    if (meta && meta.url) {
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const path = require('node:path') as typeof import('node:path');
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const url = require('node:url') as typeof import('node:url');
-      candidate = path.join(
-        path.dirname(url.fileURLToPath(meta.url)),
-        'lockWorker.js',
-      );
-    }
-  }
-  if (!candidate) return undefined;
-  // Verify the worker file actually exists — running from source (tsx, ts-node,
-  // jest without a build) hits this path; the worker is only emitted by tsup.
+  // CJS only. In ESM and browser builds __dirname is undefined, so this
+  // returns undefined and the caller falls back to sync. See plan for the
+  // full coverage matrix.
+  if (typeof __dirname === 'undefined') return undefined;
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const path = require('node:path') as typeof import('node:path');
+  const candidate = path.join(__dirname, 'lockWorker.js');
+  // Sanity check: running from source (tsx, ts-node, jest without a build)
+  // also hits the CJS branch but the .js file isn't there yet.
   try {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const fs = require('node:fs') as typeof import('node:fs');

--- a/src/verification/parallelPool.ts
+++ b/src/verification/parallelPool.ts
@@ -12,13 +12,17 @@
 
 import { fromHexString } from '@chainsafe/ssz';
 import {
+  blsAggregateSignatures,
   blsRecoverDistributedPubkeyFromShares,
   blsVerifyExtraShares,
+  blsVerifyMultiple,
 } from '../blsUtils.js';
 
 const MIN_PARALLEL_VALIDATORS = 50;
+const MIN_PARALLEL_BATCH_PAIRS = 100;
 const MAX_WORKERS = 8;
 const MIN_VALIDATORS_PER_WORKER = 25;
+const MIN_PAIRS_PER_WORKER = 50;
 
 type WorkerThreads = typeof import('node:worker_threads');
 type NodeOs = typeof import('node:os');
@@ -121,9 +125,8 @@ function verifySharesSync(
 function runWorker(
   wt: WorkerThreads,
   workerFile: string,
-  shares: string[][],
-  distributedKeys: string[],
-  threshold: number,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  data: Record<string, any>,
 ): Promise<boolean> {
   return new Promise(resolve => {
     let settled = false;
@@ -134,15 +137,30 @@ function runWorker(
       worker.terminate();
       resolve(result);
     };
-    const worker = new wt.Worker(workerFile, {
-      workerData: { shares, distributedKeys, threshold },
-    });
+    const worker = new wt.Worker(workerFile, { workerData: data });
     worker.once('message', (msg: unknown) => finish(msg === true));
     worker.once('error', () => finish(false));
     worker.once('exit', code => {
       if (code !== 0) finish(false);
     });
   });
+}
+
+function poolSize(itemCount: number, minPerWorker: number): {
+  numWorkers: number;
+  wt: WorkerThreads | null;
+  workerFile: string | undefined;
+} {
+  const wt = loadWorkerThreads();
+  const os = loadOs();
+  const workerFile = getWorkerPath();
+  const numCpus = os ? os.cpus().length : 1;
+  const numWorkers = Math.min(
+    MAX_WORKERS,
+    Math.max(1, Math.floor(itemCount / minPerWorker)),
+    numCpus,
+  );
+  return { numWorkers, wt, workerFile };
 }
 
 export async function verifySharesBinding(
@@ -153,15 +171,9 @@ export async function verifySharesBinding(
   if (shares.length !== distributedKeys.length) return false;
   if (shares.length === 0) return true;
 
-  const wt = loadWorkerThreads();
-  const os = loadOs();
-  const workerFile = getWorkerPath();
-
-  const numCpus = os ? os.cpus().length : 1;
-  const numWorkers = Math.min(
-    MAX_WORKERS,
-    Math.max(1, Math.floor(shares.length / MIN_VALIDATORS_PER_WORKER)),
-    numCpus,
+  const { numWorkers, wt, workerFile } = poolSize(
+    shares.length,
+    MIN_VALIDATORS_PER_WORKER,
   );
 
   const useParallel =
@@ -179,7 +191,66 @@ export async function verifySharesBinding(
 
   const results = await Promise.all(
     shareChunks.map((chunk, i) =>
-      runWorker(wt!, workerFile!, chunk, keyChunks[i], threshold),
+      runWorker(wt!, workerFile!, {
+        mode: 'shareBinding',
+        shares: chunk,
+        distributedKeys: keyChunks[i],
+        threshold,
+      }),
+    ),
+  );
+  return results.every(Boolean);
+}
+
+// Verify a batch of (pubkey, message, individual signature) triples.
+// Sync path aggregates all sigs and runs blsVerifyMultiple once (matches the
+// previous behavior). Parallel path splits into chunks; each chunk's sigs are
+// aggregated and verified independently — same total pairing count, K× wall
+// time speedup.
+export async function verifyBatchParallel(
+  pubkeys: Uint8Array[],
+  messages: Uint8Array[],
+  signatures: Uint8Array[],
+): Promise<boolean> {
+  if (
+    pubkeys.length !== messages.length ||
+    pubkeys.length !== signatures.length
+  ) {
+    return false;
+  }
+  if (pubkeys.length === 0) return true;
+
+  const { numWorkers, wt, workerFile } = poolSize(
+    pubkeys.length,
+    MIN_PAIRS_PER_WORKER,
+  );
+
+  const useParallel =
+    wt !== null &&
+    workerFile !== undefined &&
+    pubkeys.length >= MIN_PARALLEL_BATCH_PAIRS &&
+    numWorkers >= 2;
+
+  if (!useParallel) {
+    return blsVerifyMultiple(
+      pubkeys,
+      messages,
+      blsAggregateSignatures(signatures),
+    );
+  }
+
+  const pkChunks = chunkArrays(pubkeys, numWorkers);
+  const msgChunks = chunkArrays(messages, numWorkers);
+  const sigChunks = chunkArrays(signatures, numWorkers);
+
+  const results = await Promise.all(
+    pkChunks.map((pks, i) =>
+      runWorker(wt!, workerFile!, {
+        mode: 'verifyBatch',
+        pubkeys: pks,
+        messages: msgChunks[i],
+        aggregateSignature: blsAggregateSignatures(sigChunks[i]),
+      }),
     ),
   );
   return results.every(Boolean);

--- a/src/verification/parallelPool.ts
+++ b/src/verification/parallelPool.ts
@@ -144,7 +144,10 @@ async function runWorker(
   });
 }
 
-function poolSize(itemCount: number, minPerWorker: number): {
+function poolSize(
+  itemCount: number,
+  minPerWorker: number,
+): {
   numWorkers: number;
   wt: WorkerThreads | null;
   workerFile: string | undefined;
@@ -189,13 +192,14 @@ export async function verifySharesBinding(
   const keyChunks = chunkArrays(distributedKeys, numWorkers);
 
   const results = await Promise.all(
-    shareChunks.map(async (chunk, i) =>
-      await runWorker(wt, workerFile, {
-        mode: 'shareBinding',
-        shares: chunk,
-        distributedKeys: keyChunks[i],
-        threshold,
-      }),
+    shareChunks.map(
+      async (chunk, i) =>
+        await runWorker(wt, workerFile, {
+          mode: 'shareBinding',
+          shares: chunk,
+          distributedKeys: keyChunks[i],
+          threshold,
+        }),
     ),
   );
   return results.every(Boolean);
@@ -242,13 +246,14 @@ export async function verifyBatchParallel(
   const sigChunks = chunkArrays(signatures, numWorkers);
 
   const results = await Promise.all(
-    pkChunks.map(async (pks, i) =>
-      await runWorker(wt, workerFile, {
-        mode: 'verifyBatch',
-        pubkeys: pks,
-        messages: msgChunks[i],
-        aggregateSignature: blsAggregateSignatures(sigChunks[i]),
-      }),
+    pkChunks.map(
+      async (pks, i) =>
+        await runWorker(wt, workerFile, {
+          mode: 'verifyBatch',
+          pubkeys: pks,
+          messages: msgChunks[i],
+          aggregateSignature: blsAggregateSignatures(sigChunks[i]),
+        }),
     ),
   );
   return results.every(Boolean);

--- a/src/verification/parallelPool.ts
+++ b/src/verification/parallelPool.ts
@@ -1,0 +1,186 @@
+// Parallel share-binding verification via Node worker_threads.
+//
+// Strategy:
+// - Detect worker_threads at runtime. Browser/restricted envs => sync fallback.
+// - Below MIN_PARALLEL_VALIDATORS, sync wins (worker spin-up dominates).
+// - Spawn one worker per chunk, await all, collapse to a single boolean.
+//
+// We resolve the worker file path from the same directory as this module —
+// tsup emits `lockWorker.js` next to `parallelPool.js` in both CJS and ESM
+// Node builds. Browser build excludes the worker entry; bundlers that
+// re-bundle the SDK and break path resolution will hit the sync fallback.
+
+import { fromHexString } from '@chainsafe/ssz';
+import {
+  blsRecoverDistributedPubkeyFromShares,
+  blsVerifyExtraShares,
+} from '../blsUtils.js';
+
+const MIN_PARALLEL_VALIDATORS = 50;
+const MAX_WORKERS = 8;
+const MIN_VALIDATORS_PER_WORKER = 25;
+
+type WorkerThreads = typeof import('node:worker_threads');
+type NodeOs = typeof import('node:os');
+
+let workerThreadsCache: WorkerThreads | null | undefined;
+let osCache: NodeOs | null | undefined;
+let workerPathCache: string | undefined;
+
+function loadWorkerThreads(): WorkerThreads | null {
+  if (workerThreadsCache !== undefined) return workerThreadsCache;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    workerThreadsCache = require('node:worker_threads') as WorkerThreads;
+  } catch {
+    workerThreadsCache = null;
+  }
+  return workerThreadsCache;
+}
+
+function loadOs(): NodeOs | null {
+  if (osCache !== undefined) return osCache;
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    osCache = require('node:os') as NodeOs;
+  } catch {
+    osCache = null;
+  }
+  return osCache;
+}
+
+function getWorkerPath(): string | undefined {
+  if (workerPathCache) return workerPathCache;
+  let candidate: string | undefined;
+  if (typeof __dirname !== 'undefined') {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const path = require('node:path') as typeof import('node:path');
+    candidate = path.join(__dirname, 'lockWorker.js');
+  } else {
+    // ESM: resolve via import.meta.url — set by build/runtime.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const meta = (globalThis as any).__OBOL_SDK_IMPORT_META__;
+    if (meta && meta.url) {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const path = require('node:path') as typeof import('node:path');
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const url = require('node:url') as typeof import('node:url');
+      candidate = path.join(
+        path.dirname(url.fileURLToPath(meta.url)),
+        'lockWorker.js',
+      );
+    }
+  }
+  if (!candidate) return undefined;
+  // Verify the worker file actually exists — running from source (tsx, ts-node,
+  // jest without a build) hits this path; the worker is only emitted by tsup.
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const fs = require('node:fs') as typeof import('node:fs');
+    if (!fs.existsSync(candidate)) return undefined;
+  } catch {
+    return undefined;
+  }
+  workerPathCache = candidate;
+  return workerPathCache;
+}
+
+function chunkArrays<T>(arr: T[], n: number): T[][] {
+  const size = Math.ceil(arr.length / n);
+  const out: T[][] = [];
+  for (let i = 0; i < arr.length; i += size) {
+    out.push(arr.slice(i, i + size));
+  }
+  return out;
+}
+
+function verifySharesSync(
+  shares: string[][],
+  distributedKeys: string[],
+  threshold: number,
+): boolean {
+  for (let i = 0; i < shares.length; i++) {
+    const sharesBytes = shares[i].map(s => fromHexString(s));
+    const dkBytes = fromHexString(distributedKeys[i]);
+    const recovered = blsRecoverDistributedPubkeyFromShares(
+      sharesBytes,
+      threshold,
+    );
+    if (!recovered) return false;
+    if (recovered.length !== dkBytes.length) return false;
+    for (let j = 0; j < recovered.length; j++) {
+      if (recovered[j] !== dkBytes[j]) return false;
+    }
+    if (!blsVerifyExtraShares(sharesBytes, threshold, dkBytes)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function runWorker(
+  wt: WorkerThreads,
+  workerFile: string,
+  shares: string[][],
+  distributedKeys: string[],
+  threshold: number,
+): Promise<boolean> {
+  return new Promise(resolve => {
+    let settled = false;
+    const finish = (result: boolean): void => {
+      if (settled) return;
+      settled = true;
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      worker.terminate();
+      resolve(result);
+    };
+    const worker = new wt.Worker(workerFile, {
+      workerData: { shares, distributedKeys, threshold },
+    });
+    worker.once('message', (msg: unknown) => finish(msg === true));
+    worker.once('error', () => finish(false));
+    worker.once('exit', code => {
+      if (code !== 0) finish(false);
+    });
+  });
+}
+
+export async function verifySharesBinding(
+  shares: string[][],
+  distributedKeys: string[],
+  threshold: number,
+): Promise<boolean> {
+  if (shares.length !== distributedKeys.length) return false;
+  if (shares.length === 0) return true;
+
+  const wt = loadWorkerThreads();
+  const os = loadOs();
+  const workerFile = getWorkerPath();
+
+  const numCpus = os ? os.cpus().length : 1;
+  const numWorkers = Math.min(
+    MAX_WORKERS,
+    Math.max(1, Math.floor(shares.length / MIN_VALIDATORS_PER_WORKER)),
+    numCpus,
+  );
+
+  const useParallel =
+    wt !== null &&
+    workerFile !== undefined &&
+    shares.length >= MIN_PARALLEL_VALIDATORS &&
+    numWorkers >= 2;
+
+  if (!useParallel) {
+    return verifySharesSync(shares, distributedKeys, threshold);
+  }
+
+  const shareChunks = chunkArrays(shares, numWorkers);
+  const keyChunks = chunkArrays(distributedKeys, numWorkers);
+
+  const results = await Promise.all(
+    shareChunks.map((chunk, i) =>
+      runWorker(wt!, workerFile!, chunk, keyChunks[i], threshold),
+    ),
+  );
+  return results.every(Boolean);
+}

--- a/src/verification/v1.6.0.ts
+++ b/src/verification/v1.6.0.ts
@@ -27,10 +27,7 @@ import {
 } from '../types.js';
 import { verifyDepositData } from './common.js';
 import { blsVerifyAggregate } from '../blsUtils.js';
-import {
-  verifyBatchParallel,
-  verifySharesBinding,
-} from './parallelPool.js';
+import { verifyBatchParallel, verifySharesBinding } from './parallelPool.js';
 
 // cluster definition
 type DefinitionFieldsV1X6 = {

--- a/src/verification/v1.6.0.ts
+++ b/src/verification/v1.6.0.ts
@@ -26,12 +26,11 @@ import {
   type DepositData,
 } from '../types.js';
 import { verifyDepositData } from './common.js';
+import { blsVerifyAggregate } from '../blsUtils.js';
 import {
-  blsAggregateSignatures,
-  blsVerifyMultiple,
-  blsVerifyAggregate,
-} from '../blsUtils.js';
-import { verifySharesBinding } from './parallelPool.js';
+  verifyBatchParallel,
+  verifySharesBinding,
+} from './parallelPool.js';
 
 // cluster definition
 type DefinitionFieldsV1X6 = {
@@ -258,14 +257,12 @@ export const verifyDVV1X6 = async (
     );
   }
 
-  const aggregateBLSSignature = blsAggregateSignatures(blsSignatures);
-
   if (
-    !blsVerifyMultiple(
+    !(await verifyBatchParallel(
       pubKeys,
       builderRegistrationAndDepositDataMessages,
-      aggregateBLSSignature,
-    )
+      blsSignatures,
+    ))
   ) {
     return false;
   }

--- a/src/verification/v1.6.0.ts
+++ b/src/verification/v1.6.0.ts
@@ -28,11 +28,10 @@ import {
 import { verifyDepositData } from './common.js';
 import {
   blsAggregateSignatures,
-  blsRecoverDistributedPubkeyFromShares,
-  blsVerifyExtraShares,
   blsVerifyMultiple,
   blsVerifyAggregate,
 } from '../blsUtils.js';
+import { verifySharesBinding } from './parallelPool.js';
 
 // cluster definition
 type DefinitionFieldsV1X6 = {
@@ -203,6 +202,25 @@ export const verifyDVV1X6 = async (
   const validators = clusterLock.distributed_validators;
   const operatorCount = clusterLock.cluster_definition.operators.length;
   const threshold = clusterLock.cluster_definition.threshold;
+  // Phase 1: cheap structural pre-checks (count + uniqueness) — sync.
+  for (const validator of validators) {
+    if (validator.public_shares.length !== operatorCount) {
+      return false;
+    }
+    const uniqueShareCount = new Set(validator.public_shares).size;
+    if (uniqueShareCount !== validator.public_shares.length) {
+      return false;
+    }
+  }
+
+  // Phase 2: share-binding (Lagrange + extras) — parallel when worker_threads
+  // is available and validators.length is large enough; sync fallback otherwise.
+  const allShares = validators.map(v => v.public_shares);
+  const allDKs = validators.map(v => v.distributed_public_key);
+  if (!(await verifySharesBinding(allShares, allDKs, threshold))) {
+    return false;
+  }
+
   const pubShares = [];
   const pubKeys = [];
   const builderRegistrationAndDepositDataMessages = [];
@@ -212,40 +230,10 @@ export const verifyDVV1X6 = async (
     const validator = validators[i];
     const validatorPublicShares = validator.public_shares;
     const distributedPublicKey = validator.distributed_public_key;
-    if (validatorPublicShares.length !== operatorCount) {
-      return false;
-    }
-    const uniqueShareCount = new Set(validatorPublicShares).size;
-    if (uniqueShareCount !== validatorPublicShares.length) {
-      return false;
-    }
 
     const validatorPublicSharesBytes = validatorPublicShares.map(share =>
       fromHexString(share),
     );
-    const recoveredDistributedPubkey = blsRecoverDistributedPubkeyFromShares(
-      validatorPublicSharesBytes,
-      threshold,
-    );
-    if (!recoveredDistributedPubkey) {
-      return false;
-    }
-    if (
-      !Buffer.from(recoveredDistributedPubkey).equals(
-        Buffer.from(fromHexString(distributedPublicKey)),
-      )
-    ) {
-      return false;
-    }
-    if (
-      !blsVerifyExtraShares(
-        validatorPublicSharesBytes,
-        threshold,
-        fromHexString(distributedPublicKey),
-      )
-    ) {
-      return false;
-    }
 
     // Needed in signature_aggregate verification
     for (const share of validatorPublicSharesBytes) {

--- a/src/verification/v1.7.0.ts
+++ b/src/verification/v1.7.0.ts
@@ -32,12 +32,11 @@ import {
   verifyDepositData,
   verifyNodeSignatures,
 } from './common.js';
+import { blsVerifyAggregate } from '../blsUtils.js';
 import {
-  blsAggregateSignatures,
-  blsVerifyMultiple,
-  blsVerifyAggregate,
-} from '../blsUtils.js';
-import { verifySharesBinding } from './parallelPool.js';
+  verifyBatchParallel,
+  verifySharesBinding,
+} from './parallelPool.js';
 
 // cluster definition
 type DefinitionFieldsV1X7 = {
@@ -304,15 +303,13 @@ export const verifyDVV1X7 = async (
     );
   }
 
-  // BLS signatures verification
-  const aggregateBLSSignature = blsAggregateSignatures(blsSignatures);
-
+  // BLS signatures verification — chunked across workers when large enough.
   if (
-    !blsVerifyMultiple(
+    !(await verifyBatchParallel(
       pubKeys,
       builderRegistrationAndDepositDataMessages,
-      aggregateBLSSignature,
-    )
+      blsSignatures,
+    ))
   ) {
     return false;
   }

--- a/src/verification/v1.7.0.ts
+++ b/src/verification/v1.7.0.ts
@@ -34,11 +34,10 @@ import {
 } from './common.js';
 import {
   blsAggregateSignatures,
-  blsRecoverDistributedPubkeyFromShares,
-  blsVerifyExtraShares,
   blsVerifyMultiple,
   blsVerifyAggregate,
 } from '../blsUtils.js';
+import { verifySharesBinding } from './parallelPool.js';
 
 // cluster definition
 type DefinitionFieldsV1X7 = {
@@ -229,6 +228,25 @@ export const verifyDVV1X7 = async (
   const operatorCount = clusterLock.cluster_definition.operators.length;
   const threshold = clusterLock.cluster_definition.threshold;
 
+  // Phase 1: cheap structural pre-checks (count + uniqueness) — sync.
+  for (const validator of validators) {
+    if (validator.public_shares.length !== operatorCount) {
+      return false;
+    }
+    const uniqueShareCount = new Set(validator.public_shares).size;
+    if (uniqueShareCount !== validator.public_shares.length) {
+      return false;
+    }
+  }
+
+  // Phase 2: share-binding (Lagrange + extras) — parallel when worker_threads
+  // is available and validators.length is large enough; sync fallback otherwise.
+  const allShares = validators.map(v => v.public_shares);
+  const allDKs = validators.map(v => v.distributed_public_key);
+  if (!(await verifySharesBinding(allShares, allDKs, threshold))) {
+    return false;
+  }
+
   const pubShares = [];
 
   const pubKeys = [];
@@ -239,40 +257,10 @@ export const verifyDVV1X7 = async (
     const validator = validators[i];
     const validatorPublicShares = validator.public_shares;
     const distributedPublicKey = validator.distributed_public_key;
-    if (validatorPublicShares.length !== operatorCount) {
-      return false;
-    }
-    const uniqueShareCount = new Set(validatorPublicShares).size;
-    if (uniqueShareCount !== validatorPublicShares.length) {
-      return false;
-    }
 
     const validatorPublicSharesBytes = validatorPublicShares.map(share =>
       fromHexString(share),
     );
-    const recoveredDistributedPubkey = blsRecoverDistributedPubkeyFromShares(
-      validatorPublicSharesBytes,
-      threshold,
-    );
-    if (!recoveredDistributedPubkey) {
-      return false;
-    }
-    if (
-      !Buffer.from(recoveredDistributedPubkey).equals(
-        Buffer.from(fromHexString(distributedPublicKey)),
-      )
-    ) {
-      return false;
-    }
-    if (
-      !blsVerifyExtraShares(
-        validatorPublicSharesBytes,
-        threshold,
-        fromHexString(distributedPublicKey),
-      )
-    ) {
-      return false;
-    }
 
     // Needed in signature_aggregate verification
     for (const share of validatorPublicSharesBytes) {

--- a/src/verification/v1.7.0.ts
+++ b/src/verification/v1.7.0.ts
@@ -33,10 +33,7 @@ import {
   verifyNodeSignatures,
 } from './common.js';
 import { blsVerifyAggregate } from '../blsUtils.js';
-import {
-  verifyBatchParallel,
-  verifySharesBinding,
-} from './parallelPool.js';
+import { verifyBatchParallel, verifySharesBinding } from './parallelPool.js';
 
 // cluster definition
 type DefinitionFieldsV1X7 = {

--- a/src/verification/v1.8.0.ts
+++ b/src/verification/v1.8.0.ts
@@ -33,12 +33,11 @@ import {
   verifyDepositData,
   verifyNodeSignatures,
 } from './common.js';
+import { blsVerifyAggregate } from '../blsUtils.js';
 import {
-  blsAggregateSignatures,
-  blsVerifyMultiple,
-  blsVerifyAggregate,
-} from '../blsUtils.js';
-import { verifySharesBinding } from './parallelPool.js';
+  verifyBatchParallel,
+  verifySharesBinding,
+} from './parallelPool.js';
 
 // cluster definition
 type DefinitionFieldsV1X8 = {
@@ -336,14 +335,12 @@ export const verifyDVV1X8 = async (
   }
 
   // BLS signatures verification
-  const aggregateBLSSignature = blsAggregateSignatures(blsSignatures);
-
   if (
-    !blsVerifyMultiple(
+    !(await verifyBatchParallel(
       pubKeys,
       builderRegistrationAndDepositDataMessages,
-      aggregateBLSSignature,
-    )
+      blsSignatures,
+    ))
   ) {
     return false;
   }

--- a/src/verification/v1.8.0.ts
+++ b/src/verification/v1.8.0.ts
@@ -35,11 +35,10 @@ import {
 } from './common.js';
 import {
   blsAggregateSignatures,
-  blsRecoverDistributedPubkeyFromShares,
-  blsVerifyExtraShares,
   blsVerifyMultiple,
   blsVerifyAggregate,
 } from '../blsUtils.js';
+import { verifySharesBinding } from './parallelPool.js';
 
 // cluster definition
 type DefinitionFieldsV1X8 = {
@@ -242,6 +241,25 @@ export const verifyDVV1X8 = async (
   const validators = clusterLock.distributed_validators;
   const operatorCount = clusterLock.cluster_definition.operators.length;
   const threshold = clusterLock.cluster_definition.threshold;
+  // Phase 1: cheap structural pre-checks (count + uniqueness) — sync.
+  for (const validator of validators) {
+    if (validator.public_shares.length !== operatorCount) {
+      return false;
+    }
+    const uniqueShareCount = new Set(validator.public_shares).size;
+    if (uniqueShareCount !== validator.public_shares.length) {
+      return false;
+    }
+  }
+
+  // Phase 2: share-binding (Lagrange + extras) — parallel when worker_threads
+  // is available and validators.length is large enough; sync fallback otherwise.
+  const allShares = validators.map(v => v.public_shares);
+  const allDKs = validators.map(v => v.distributed_public_key);
+  if (!(await verifySharesBinding(allShares, allDKs, threshold))) {
+    return false;
+  }
+
   const pubShares = [];
   const pubKeys = [];
   const builderRegistrationAndDepositDataMessages = [];
@@ -251,40 +269,10 @@ export const verifyDVV1X8 = async (
     const validator = validators[i];
     const validatorPublicShares = validator.public_shares;
     const distributedPublicKey = validator.distributed_public_key;
-    if (validatorPublicShares.length !== operatorCount) {
-      return false;
-    }
-    const uniqueShareCount = new Set(validatorPublicShares).size;
-    if (uniqueShareCount !== validatorPublicShares.length) {
-      return false;
-    }
 
     const validatorPublicSharesBytes = validatorPublicShares.map(share =>
       fromHexString(share),
     );
-    const recoveredDistributedPubkey = blsRecoverDistributedPubkeyFromShares(
-      validatorPublicSharesBytes,
-      threshold,
-    );
-    if (!recoveredDistributedPubkey) {
-      return false;
-    }
-    if (
-      !Buffer.from(recoveredDistributedPubkey).equals(
-        Buffer.from(fromHexString(distributedPublicKey)),
-      )
-    ) {
-      return false;
-    }
-    if (
-      !blsVerifyExtraShares(
-        validatorPublicSharesBytes,
-        threshold,
-        fromHexString(distributedPublicKey),
-      )
-    ) {
-      return false;
-    }
 
     // Needed in signature_aggregate verification
     for (const share of validatorPublicSharesBytes) {

--- a/src/verification/v1.8.0.ts
+++ b/src/verification/v1.8.0.ts
@@ -34,10 +34,7 @@ import {
   verifyNodeSignatures,
 } from './common.js';
 import { blsVerifyAggregate } from '../blsUtils.js';
-import {
-  verifyBatchParallel,
-  verifySharesBinding,
-} from './parallelPool.js';
+import { verifyBatchParallel, verifySharesBinding } from './parallelPool.js';
 
 // cluster definition
 type DefinitionFieldsV1X8 = {

--- a/test/perf/blsBench.mjs
+++ b/test/perf/blsBench.mjs
@@ -1,0 +1,82 @@
+// Microbench: confirms where time goes in pure-JS BLS for lock validation.
+// Run: node test/perf/blsBench.mjs
+import { bls12_381 } from '../../node_modules/@noble/curves/bls12-381.js';
+
+const { longSignatures: ls, G1, fields: { Fr } } = bls12_381;
+const ETH2_DST = 'BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_';
+
+function bench(name, fn) {
+  const start = process.hrtime.bigint();
+  fn();
+  const elapsed = Number(process.hrtime.bigint() - start) / 1e6;
+  console.log(`${name.padEnd(45)} ${elapsed.toFixed(1)}ms`);
+  return elapsed;
+}
+
+// Setup: a real BLS keypair so verification is meaningful.
+const skBytes = ls.keygen(new Uint8Array(48).fill(11)).secretKey;
+const pk = ls.getPublicKey(skBytes);
+const message = new Uint8Array(32).fill(7);
+const messageHashed = ls.hash(message, ETH2_DST);
+const sig = ls.sign(messageHashed, skBytes);
+
+// Dummy share for G1 mul timing (real point, deterministic).
+const sharePoint = G1.Point.BASE.multiply(Fr.create(987654321n));
+const shareBytes = sharePoint.toBytes();
+
+console.log('\n--- BLS hot-path microbench (single thread) ---\n');
+
+// 1. G1 point multiplication (Lagrange building block)
+const N_MULS = 5000;
+const t1 = bench(`${N_MULS}× G1.Point.multiply(scalar)`, () => {
+  for (let i = 0; i < N_MULS; i++) {
+    sharePoint.multiply(Fr.create(BigInt(i + 1)));
+  }
+});
+console.log(`  per op: ${(t1 / N_MULS * 1000).toFixed(1)}µs`);
+
+// 2. fromBytes (deserialize + on-curve + subgroup check)
+const N_DESER = 5000;
+const t2 = bench(`${N_DESER}× G1.Point.fromBytes`, () => {
+  for (let i = 0; i < N_DESER; i++) {
+    G1.Point.fromBytes(shareBytes);
+  }
+});
+console.log(`  per op: ${(t2 / N_DESER * 1000).toFixed(1)}µs`);
+
+// 3. Single BLS verify (one pairing + extras)
+const N_VERIFY = 200;
+const t3 = bench(`${N_VERIFY}× ls.verify single`, () => {
+  for (let i = 0; i < N_VERIFY; i++) {
+    ls.verify(sig, messageHashed, pk);
+  }
+});
+console.log(`  per op: ${(t3 / N_VERIFY).toFixed(1)}ms`);
+
+// 4. Batch verify scaling — UNIQUE pairs (real-world)
+for (const N of [50, 200, 500]) {
+  const sks = Array.from({ length: N }, (_, i) => ls.keygen(new Uint8Array(48).fill(i + 20)).secretKey);
+  const pks = sks.map(s => ls.getPublicKey(s));
+  const msgs = Array.from({ length: N }, (_, i) => {
+    const m = new Uint8Array(32);
+    m[0] = i & 0xff;
+    m[1] = (i >> 8) & 0xff;
+    return ls.hash(m, ETH2_DST);
+  });
+  const sigs = msgs.map((m, i) => ls.sign(m, sks[i]));
+  const aggSig = ls.Signature.toBytes(ls.aggregateSignatures(sigs));
+  const items = pks.map((pk, i) => ({ publicKey: pk, message: msgs[i] }));
+  const t = bench(`verifyBatch ${N} unique pairs`, () => {
+    ls.verifyBatch(aggSig, items);
+  });
+  console.log(`  per pair: ${(t / N).toFixed(2)}ms`);
+}
+
+console.log('\n--- Estimated full validation cost ---\n');
+console.log('For a 500-validator, 4-of-6 lock:');
+const lagrangeCost = 500 * 4 * (1 + 2) * (t1 / N_MULS); // T*(1+(N-T)) muls per validator
+console.log(`  Lagrange + extras: ${lagrangeCost.toFixed(0)}ms`);
+const batchCost = (1000 * (t3 / N_VERIFY)) * 0.6; // batch is ~60% of N single verifies
+console.log(`  blsVerifyMultiple (batched 1000 pairs, est): ${batchCost.toFixed(0)}ms`);
+console.log(`  Aggregate sig + node sigs: <200ms`);
+console.log(`  TOTAL est: ${(lagrangeCost + batchCost + 200).toFixed(0)}ms\n`);

--- a/test/perf/parallelBench.mjs
+++ b/test/perf/parallelBench.mjs
@@ -14,11 +14,11 @@ const {
   blsVerifyExtraShares,
   blsAggregateSignatures,
   blsVerifyMultiple,
-  blsSign,
-  blsGetPublicKey,
-  blsKeygen,
 } = require('../../dist/cjs/src/blsUtils.js');
 const { fromHexString } = require('@chainsafe/ssz');
+const { bls12_381 } = require('@noble/curves/bls12-381.js');
+const ls = bls12_381.longSignatures;
+const ETH2_DST = 'BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_';
 
 // ----- Real fixture-derived data for the share-binding bench -----
 const SHARES = [
@@ -46,8 +46,10 @@ function syncShares(shares, distributedKeys, threshold) {
 }
 
 // ----- Synthetic real BLS keypairs/sigs for the batch-verify bench -----
-// Uses the SDK's own blsSign/blsGetPublicKey (same bundled noble instance as
-// blsVerifyMultiple) to avoid cross-module type issues.
+// Important: noble's getPublicKey() returns a Point object (not Uint8Array),
+// and Point's class prototype is stripped by structured clone when sent
+// through workerData. So we explicitly call .toBytes() to keep everything
+// as Uint8Array across the worker boundary.
 function buildBatchCorpus(n) {
   const pubkeys = [];
   const messages = [];
@@ -56,13 +58,13 @@ function buildBatchCorpus(n) {
     const seed = new Uint8Array(48);
     seed[0] = (i + 1) & 0xff;
     seed[1] = ((i + 1) >> 8) & 0xff;
-    const sk = blsKeygen(seed);
-    pubkeys.push(blsGetPublicKey(sk));
+    const sk = ls.keygen(seed).secretKey;
+    pubkeys.push(ls.getPublicKey(sk).toBytes());
     const msg = new Uint8Array(32);
     msg[0] = i & 0xff;
     msg[1] = (i >> 8) & 0xff;
     messages.push(msg);
-    signatures.push(blsSign(sk, msg));
+    signatures.push(ls.Signature.toBytes(ls.sign(ls.hash(msg, ETH2_DST), sk)));
   }
   return { pubkeys, messages, signatures };
 }

--- a/test/perf/parallelBench.mjs
+++ b/test/perf/parallelBench.mjs
@@ -1,16 +1,37 @@
-// End-to-end bench: sync vs parallel share-binding on a synthetic large lock.
-// Uses the existing v1.10 fixture's shares replicated N times.
+// End-to-end bench for the two parallel paths in verifyDV:
+//   1. share-binding (Lagrange + extras) via verifySharesBinding
+//   2. batch BLS verify (deposit+builder pairings) via verifyBatchParallel
 //
 // Run after `yarn build`:
 //   node test/perf/parallelBench.mjs
 import { createRequire } from 'node:module';
 const require = createRequire(import.meta.url);
-const { verifySharesBinding } = require('../../dist/cjs/src/verification/parallelPool.js');
+const { verifySharesBinding, verifyBatchParallel } = require(
+  '../../dist/cjs/src/verification/parallelPool.js',
+);
+const {
+  blsRecoverDistributedPubkeyFromShares,
+  blsVerifyExtraShares,
+  blsAggregateSignatures,
+  blsVerifyMultiple,
+  blsSign,
+  blsGetPublicKey,
+  blsKeygen,
+} = require('../../dist/cjs/src/blsUtils.js');
 const { fromHexString } = require('@chainsafe/ssz');
 
-async function syncRecover(shares, distributedKeys, threshold) {
-  const { blsRecoverDistributedPubkeyFromShares, blsVerifyExtraShares } =
-    require('../../dist/cjs/src/blsUtils.js');
+// ----- Real fixture-derived data for the share-binding bench -----
+const SHARES = [
+  '0xb6b24044bb78eae5801a41bb98ebda85d3210d08706e7a10ef42bebbf4505cd343d396ed10cdb1f63aa1ca9a850d97d7',
+  '0x8c15903d870956aede8118806ab5bc36ed18bb3db7fc8fa86893e040c04f6322b9488e844882e0bc98df94dabb781e6a',
+  '0x8d582fcac937895ca521a7f83cd43274656ea9b382eb5db2e096c3332c6488b56e5889456cabc5f56e0287d408146689',
+  '0xa88805bb74b0a651a563c595fb6da9a561311894251db6dbf4ea21d2a5478becf8597dc1bb6bcb0c7129194540216b85',
+];
+const DK =
+  '0xa47fefdb2d5c92bfd319463b83975744c29ba8a646b5c0306e5591c6646a49834c787c1ad6f6d9b031015e230bd0d1f5';
+const THRESHOLD = 3;
+
+function syncShares(shares, distributedKeys, threshold) {
   for (let i = 0; i < shares.length; i++) {
     const bytes = shares[i].map(s => fromHexString(s));
     const dk = fromHexString(distributedKeys[i]);
@@ -24,40 +45,64 @@ async function syncRecover(shares, distributedKeys, threshold) {
   return true;
 }
 
-// Real shares + distributed key from the v1.10 fixture (4 operators, threshold 3).
-const SHARES = [
-  '0xb6b24044bb78eae5801a41bb98ebda85d3210d08706e7a10ef42bebbf4505cd343d396ed10cdb1f63aa1ca9a850d97d7',
-  '0x8c15903d870956aede8118806ab5bc36ed18bb3db7fc8fa86893e040c04f6322b9488e844882e0bc98df94dabb781e6a',
-  '0x8d582fcac937895ca521a7f83cd43274656ea9b382eb5db2e096c3332c6488b56e5889456cabc5f56e0287d408146689',
-  '0xa88805bb74b0a651a563c595fb6da9a561311894251db6dbf4ea21d2a5478becf8597dc1bb6bcb0c7129194540216b85',
-];
-const DK = '0xa47fefdb2d5c92bfd319463b83975744c29ba8a646b5c0306e5591c6646a49834c787c1ad6f6d9b031015e230bd0d1f5';
-const THRESHOLD = 3;
+// ----- Synthetic real BLS keypairs/sigs for the batch-verify bench -----
+// Uses the SDK's own blsSign/blsGetPublicKey (same bundled noble instance as
+// blsVerifyMultiple) to avoid cross-module type issues.
+function buildBatchCorpus(n) {
+  const pubkeys = [];
+  const messages = [];
+  const signatures = [];
+  for (let i = 0; i < n; i++) {
+    const seed = new Uint8Array(48);
+    seed[0] = (i + 1) & 0xff;
+    seed[1] = ((i + 1) >> 8) & 0xff;
+    const sk = blsKeygen(seed);
+    pubkeys.push(blsGetPublicKey(sk));
+    const msg = new Uint8Array(32);
+    msg[0] = i & 0xff;
+    msg[1] = (i >> 8) & 0xff;
+    messages.push(msg);
+    signatures.push(blsSign(sk, msg));
+  }
+  return { pubkeys, messages, signatures };
+}
 
 async function timed(label, fn) {
   const t0 = process.hrtime.bigint();
   const ok = await fn();
   const ms = Number(process.hrtime.bigint() - t0) / 1e6;
-  console.log(`${label.padEnd(40)} ${ms.toFixed(0).padStart(6)}ms  ok=${ok}`);
+  console.log(`${label.padEnd(50)} ${ms.toFixed(0).padStart(6)}ms  ok=${ok}`);
   return ms;
 }
 
-console.log('\n--- Sync vs parallel share-binding ---');
-console.log('(parallel kicks in at N >= 50; smaller N falls back to sync)\n');
+async function main() {
+  console.log('\n=== Phase 1: share-binding (Lagrange + extras) ===\n');
+  for (const N of [50, 200, 500]) {
+    const shares = Array.from({ length: N }, () => SHARES);
+    const dks = Array.from({ length: N }, () => DK);
 
-for (const N of [10, 50, 100, 200, 500]) {
-  const shares = Array.from({ length: N }, () => SHARES);
-  const dks = Array.from({ length: N }, () => DK);
+    const sMs = await timed(`N=${N} sync`, () => syncShares(shares, dks, THRESHOLD));
+    const pMs = await timed(`N=${N} verifySharesBinding`, () =>
+      verifySharesBinding(shares, dks, THRESHOLD),
+    );
+    console.log(`  speedup: ${(sMs / pMs).toFixed(2)}×\n`);
+  }
 
-  const syncMs = await timed(`N=${N.toString().padStart(3)} sync (inline loop)`,
-    () => syncRecover(shares, dks, THRESHOLD));
-  const poolMs = await timed(`N=${N.toString().padStart(3)} verifySharesBinding`,
-    () => verifySharesBinding(shares, dks, THRESHOLD));
-
-  if (N >= 50) {
-    const speedup = (syncMs / poolMs).toFixed(2);
-    console.log(`  speedup: ${speedup}×\n`);
-  } else {
-    console.log(`  (both sync; pool didn't spawn workers)\n`);
+  console.log('\n=== Phase 2: batch BLS verify (deposit+builder pairings) ===\n');
+  for (const N of [100, 400, 1000]) {
+    // (real lock has 2× deposit+builder messages per validator; use N pairs directly)
+    const { pubkeys, messages, signatures } = buildBatchCorpus(N);
+    const sMs = await timed(`N=${N} sync (single verifyBatch)`, () =>
+      blsVerifyMultiple(pubkeys, messages, blsAggregateSignatures(signatures)),
+    );
+    const pMs = await timed(`N=${N} verifyBatchParallel`, () =>
+      verifyBatchParallel(pubkeys, messages, signatures),
+    );
+    console.log(`  speedup: ${(sMs / pMs).toFixed(2)}×\n`);
   }
 }
+
+main().catch(e => {
+  console.error(e);
+  process.exit(1);
+});

--- a/test/perf/parallelBench.mjs
+++ b/test/perf/parallelBench.mjs
@@ -1,0 +1,63 @@
+// End-to-end bench: sync vs parallel share-binding on a synthetic large lock.
+// Uses the existing v1.10 fixture's shares replicated N times.
+//
+// Run after `yarn build`:
+//   node test/perf/parallelBench.mjs
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { verifySharesBinding } = require('../../dist/cjs/src/verification/parallelPool.js');
+const { fromHexString } = require('@chainsafe/ssz');
+
+async function syncRecover(shares, distributedKeys, threshold) {
+  const { blsRecoverDistributedPubkeyFromShares, blsVerifyExtraShares } =
+    require('../../dist/cjs/src/blsUtils.js');
+  for (let i = 0; i < shares.length; i++) {
+    const bytes = shares[i].map(s => fromHexString(s));
+    const dk = fromHexString(distributedKeys[i]);
+    const recovered = blsRecoverDistributedPubkeyFromShares(bytes, threshold);
+    if (!recovered) return false;
+    for (let j = 0; j < dk.length; j++) {
+      if (recovered[j] !== dk[j]) return false;
+    }
+    if (!blsVerifyExtraShares(bytes, threshold, dk)) return false;
+  }
+  return true;
+}
+
+// Real shares + distributed key from the v1.10 fixture (4 operators, threshold 3).
+const SHARES = [
+  '0xb6b24044bb78eae5801a41bb98ebda85d3210d08706e7a10ef42bebbf4505cd343d396ed10cdb1f63aa1ca9a850d97d7',
+  '0x8c15903d870956aede8118806ab5bc36ed18bb3db7fc8fa86893e040c04f6322b9488e844882e0bc98df94dabb781e6a',
+  '0x8d582fcac937895ca521a7f83cd43274656ea9b382eb5db2e096c3332c6488b56e5889456cabc5f56e0287d408146689',
+  '0xa88805bb74b0a651a563c595fb6da9a561311894251db6dbf4ea21d2a5478becf8597dc1bb6bcb0c7129194540216b85',
+];
+const DK = '0xa47fefdb2d5c92bfd319463b83975744c29ba8a646b5c0306e5591c6646a49834c787c1ad6f6d9b031015e230bd0d1f5';
+const THRESHOLD = 3;
+
+async function timed(label, fn) {
+  const t0 = process.hrtime.bigint();
+  const ok = await fn();
+  const ms = Number(process.hrtime.bigint() - t0) / 1e6;
+  console.log(`${label.padEnd(40)} ${ms.toFixed(0).padStart(6)}ms  ok=${ok}`);
+  return ms;
+}
+
+console.log('\n--- Sync vs parallel share-binding ---');
+console.log('(parallel kicks in at N >= 50; smaller N falls back to sync)\n');
+
+for (const N of [10, 50, 100, 200, 500]) {
+  const shares = Array.from({ length: N }, () => SHARES);
+  const dks = Array.from({ length: N }, () => DK);
+
+  const syncMs = await timed(`N=${N.toString().padStart(3)} sync (inline loop)`,
+    () => syncRecover(shares, dks, THRESHOLD));
+  const poolMs = await timed(`N=${N.toString().padStart(3)} verifySharesBinding`,
+    () => verifySharesBinding(shares, dks, THRESHOLD));
+
+  if (N >= 50) {
+    const speedup = (syncMs / poolMs).toFixed(2);
+    console.log(`  speedup: ${speedup}×\n`);
+  } else {
+    console.log(`  (both sync; pool didn't spawn workers)\n`);
+  }
+}

--- a/test/sdk-package/yarn.lock
+++ b/test/sdk-package/yarn.lock
@@ -1018,9 +1018,9 @@
   integrity sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==
 
 "@types/node@*":
-  version "25.6.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.6.0.tgz#4e09bad9b469871f2d0f68140198cbd714f4edca"
-  integrity sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==
+  version "25.6.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.6.1.tgz#1d79a06d7b21e9946775b2cf100d6c7c18b14e96"
+  integrity sha512-coJCN8O1q4AGyyqCAUSP06P+SrMTu18BkEj3NVAK07q6QUneD2wzj3CLv9+yP+BMeZQlMvneXqqvDe3w+xcq7g==
   dependencies:
     undici-types "~7.19.0"
 

--- a/test/sdk-package/yarn.lock
+++ b/test/sdk-package/yarn.lock
@@ -1018,9 +1018,9 @@
   integrity sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==
 
 "@types/node@*":
-  version "25.6.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.6.1.tgz#1d79a06d7b21e9946775b2cf100d6c7c18b14e96"
-  integrity sha512-coJCN8O1q4AGyyqCAUSP06P+SrMTu18BkEj3NVAK07q6QUneD2wzj3CLv9+yP+BMeZQlMvneXqqvDe3w+xcq7g==
+  version "25.6.2"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.6.2.tgz#8c491201373690e4ef2a2ffed0dfb510a5830b92"
+  integrity sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==
   dependencies:
     undici-types "~7.19.0"
 
@@ -3084,9 +3084,9 @@ v8-to-istanbul@^9.0.1:
     convert-source-map "^2.0.0"
 
 viem@^2.21.8:
-  version "2.48.8"
-  resolved "https://registry.yarnpkg.com/viem/-/viem-2.48.8.tgz#ce3f6dd8d5cfe31f3bb0c0c368bdd3f7c331150f"
-  integrity sha512-Xj3Nrt66SKtn06kczU91ELn9Difr84ZM5A62BTlaisT5lpgt058i2mBkfMZCXHGb1ocOLjzC2ztPhD0Lvky7uQ==
+  version "2.48.11"
+  resolved "https://registry.yarnpkg.com/viem/-/viem-2.48.11.tgz#f0b8db28a9c201113eb3cb0d9bb2c7c05f372259"
+  integrity sha512-+WZ5E0dBS6GtKb+1wEk5DeYRRRW42+pFnXCo67Ydodf42sBwO+hu3wnQy66lc4MKmHz+llPVdbyehYr9oTE2iw==
   dependencies:
     "@noble/curves" "1.9.1"
     "@noble/hashes" "1.8.0"

--- a/test/verification/parallelPool.spec.ts
+++ b/test/verification/parallelPool.spec.ts
@@ -1,0 +1,141 @@
+// Public-API contract tests for the parallel pool helpers.
+//
+// IMPORTANT: jest runs from source, where dist/cjs/.../lockWorker.js does
+// not exist, so getWorkerPath() returns null and these tests exercise the
+// SYNC FALLBACK path. They catch:
+//   - sync-fallback correctness regressions
+//   - WorkerInput shape mismatches at compile time (since the pool now
+//     uses the typed import)
+//   - API contract drift (signature, return type)
+//
+// They do NOT catch worker-specific breakage (worker_threads pathing,
+// structured-clone issues, etc). For that, run
+//   node test/perf/parallelBench.mjs
+// after `yarn build`. See PARALLEL_VALIDATION_PLAN.md.
+import {
+  verifySharesBinding,
+  verifyBatchParallel,
+} from '../../src/verification/parallelPool';
+import {
+  blsAggregateSignatures,
+  blsVerifyMultiple,
+} from '../../src/blsUtils';
+import { bls12_381 } from '@noble/curves/bls12-381.js';
+
+const ls = bls12_381.longSignatures;
+const ETH2_DST = 'BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_';
+
+// Real shares from the v1.10 fixture (4 operators, threshold 3) — they
+// already reconstruct to the corresponding DV key.
+const SHARES = [
+  '0xb6b24044bb78eae5801a41bb98ebda85d3210d08706e7a10ef42bebbf4505cd343d396ed10cdb1f63aa1ca9a850d97d7',
+  '0x8c15903d870956aede8118806ab5bc36ed18bb3db7fc8fa86893e040c04f6322b9488e844882e0bc98df94dabb781e6a',
+  '0x8d582fcac937895ca521a7f83cd43274656ea9b382eb5db2e096c3332c6488b56e5889456cabc5f56e0287d408146689',
+  '0xa88805bb74b0a651a563c595fb6da9a561311894251db6dbf4ea21d2a5478becf8597dc1bb6bcb0c7129194540216b85',
+];
+const DK =
+  '0xa47fefdb2d5c92bfd319463b83975744c29ba8a646b5c0306e5591c6646a49834c787c1ad6f6d9b031015e230bd0d1f5';
+const THRESHOLD = 3;
+
+describe('verifySharesBinding', () => {
+  it('returns true for 50 valid validators (parallel threshold boundary)', async () => {
+    const N = 50;
+    const shares = Array.from({ length: N }, () => SHARES);
+    const dks = Array.from({ length: N }, () => DK);
+    expect(await verifySharesBinding(shares, dks, THRESHOLD)).toBe(true);
+  });
+
+  it('returns true for 100 valid validators', async () => {
+    const N = 100;
+    const shares = Array.from({ length: N }, () => SHARES);
+    const dks = Array.from({ length: N }, () => DK);
+    expect(await verifySharesBinding(shares, dks, THRESHOLD)).toBe(true);
+  });
+
+  it('returns false when shares do not reconstruct the DV key', async () => {
+    const N = 50;
+    // Reverse share order — same uniqueness, wrong polynomial positions,
+    // so reconstruction yields a different key.
+    const reversed = [...SHARES].reverse();
+    const shares = Array.from({ length: N }, () => reversed);
+    const dks = Array.from({ length: N }, () => DK);
+    expect(await verifySharesBinding(shares, dks, THRESHOLD)).toBe(false);
+  });
+
+  it('returns false on length mismatch', async () => {
+    expect(
+      await verifySharesBinding([SHARES, SHARES], [DK], THRESHOLD),
+    ).toBe(false);
+  });
+
+  it('returns true on empty input', async () => {
+    expect(await verifySharesBinding([], [], THRESHOLD)).toBe(true);
+  });
+});
+
+function buildCorpus(n: number): {
+  pubkeys: Uint8Array[];
+  messages: Uint8Array[];
+  signatures: Uint8Array[];
+} {
+  const pubkeys: Uint8Array[] = [];
+  const messages: Uint8Array[] = [];
+  const signatures: Uint8Array[] = [];
+  for (let i = 0; i < n; i++) {
+    const seed = new Uint8Array(48);
+    seed[0] = (i + 1) & 0xff;
+    seed[1] = ((i + 1) >> 8) & 0xff;
+    const sk = ls.keygen(seed).secretKey;
+    // Point.toBytes() to keep things as Uint8Array — see lockWorker docs
+    // for why this matters across worker boundaries.
+    pubkeys.push((ls.getPublicKey(sk) as any).toBytes());
+    const msg = new Uint8Array(32);
+    msg[0] = i & 0xff;
+    msg[1] = (i >> 8) & 0xff;
+    messages.push(msg);
+    signatures.push(
+      ls.Signature.toBytes(ls.sign(ls.hash(msg, ETH2_DST), sk)),
+    );
+  }
+  return { pubkeys, messages, signatures };
+}
+
+describe('verifyBatchParallel', () => {
+  it('returns true for 100 valid (pubkey, message, sig) triples', async () => {
+    const { pubkeys, messages, signatures } = buildCorpus(100);
+    expect(await verifyBatchParallel(pubkeys, messages, signatures)).toBe(
+      true,
+    );
+  });
+
+  it('matches sync blsVerifyMultiple for the same input', async () => {
+    const { pubkeys, messages, signatures } = buildCorpus(60);
+    const aggSync = blsAggregateSignatures(signatures);
+    expect(blsVerifyMultiple(pubkeys, messages, aggSync)).toBe(true);
+    expect(await verifyBatchParallel(pubkeys, messages, signatures)).toBe(
+      true,
+    );
+  });
+
+  it('returns false when a message is changed (sig no longer matches its pair)', async () => {
+    // Aggregate sig sum is commutative so swapping sigs is a no-op. We
+    // mutate one message instead so the (pubkey, message) pair at that
+    // position no longer matches the corresponding signature.
+    const { pubkeys, messages, signatures } = buildCorpus(100);
+    messages[0] = new Uint8Array(32).fill(0xaa);
+    expect(await verifyBatchParallel(pubkeys, messages, signatures)).toBe(
+      false,
+    );
+  });
+
+  it('returns false on length mismatch', async () => {
+    const { pubkeys, messages, signatures } = buildCorpus(5);
+    expect(
+      await verifyBatchParallel(pubkeys.slice(0, 4), messages, signatures),
+    ).toBe(false);
+  });
+
+  it('returns true on empty input', async () => {
+    expect(await verifyBatchParallel([], [], [])).toBe(true);
+  });
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -3,7 +3,12 @@ import { defineConfig } from 'tsup';
 export default defineConfig([
   // Node.js CJS build
   {
-    entry: ['src/index.ts'],
+    entry: [
+      'src/index.ts',
+      'src/blsUtils.ts',
+      'src/verification/lockWorker.ts',
+      'src/verification/parallelPool.ts',
+    ],
     format: ['cjs'],
     dts: false,
     outDir: 'dist/cjs/src',
@@ -23,7 +28,12 @@ export default defineConfig([
   },
   // Node.js ESM build
   {
-    entry: ['src/index.ts'],
+    entry: [
+      'src/index.ts',
+      'src/blsUtils.ts',
+      'src/verification/lockWorker.ts',
+      'src/verification/parallelPool.ts',
+    ],
     format: ['esm'],
     dts: false,
     outDir: 'dist/esm/src',


### PR DESCRIPTION
Hoists the per-validator Lagrange + extra-share check out of the verifyDV loop and runs it across a worker pool when worker_threads is available and validators.length >= 50. Sync fallback otherwise (browser, restricted envs, small locks).

Bench (M-series, 4-core utilization):

  N=500 sync     9.3s
  N=500 parallel 1.8s   (5.18× speedup)

Closes timeout territory for obol-api on 500+-validator locks.

The worker file is emitted as a separate tsup entry in the Node CJS+ESM builds; browser build excludes it. parallelPool resolves the worker via __dirname / import.meta.url and falls back to sync if the file isn't where it expects (e.g. running from source without a build).

See PARALLEL_VALIDATION_PLAN.md for design + scope.