### PR TITLE
fix: sign release PR commits for branch protection compliance

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -75,3 +75,4 @@ jobs:
             automated pr
           signoff: false
           draft: false
+          sign-commits: true


### PR DESCRIPTION
## Summary

- Add `sign-commits: true` to the `peter-evans/create-pull-request` step in the release workflow
- This uses the GitHub API (instead of local `git push`) to create commits, so they are automatically signed by GitHub's key — satisfying the `required_signatures` branch protection on `main`

## Context

After enabling "Require signed commits" on `main`, the release-pr workflow produced unsigned commits (commit `246476c`), blocking the merge of PR #203. 

## Test plan

- [ ] Trigger the release-pr workflow (`workflow_dispatch`) and verify the commit on the `release` branch shows as "Verified" on GitHub
- [ ] Verify the resulting PR can be merged without manual re-signing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release process with commit signing to ensure the authenticity and integrity of release pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->