### PR TITLE
Hanan/timeoutError+ConcurrentRequests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. Dates are d
 #### Unreleased
 
 - fix: propagate per-chunk BLS worker timeouts as `ClusterLockValidationTimeoutError` (504) instead of invalid-lock `false` (400)
+- feat: cap concurrent `validateClusterLock` calls (`OBOL_SDK_MAX_CONCURRENT_LOCK_VALIDATIONS`, default 2) with `ClusterLockValidationBusyError` (503)
 
 #### [v2.12.2](https://github.com/ObolNetwork/obol-sdk/compare/v2.12.1...v2.12.2)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. Dates are displayed in UTC.
 
+#### Unreleased
+
+- fix: propagate per-chunk BLS worker timeouts as `ClusterLockValidationTimeoutError` (504) instead of invalid-lock `false` (400)
+
 #### [v2.12.2](https://github.com/ObolNetwork/obol-sdk/compare/v2.12.1...v2.12.2)
 
 - fix(security): stop auto-loading .env and allowlist Obol API baseUrl [`#210`](https://github.com/ObolNetwork/obol-sdk/pull/210)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,7 +224,7 @@ else sync `isValidClusterLock` in `common.ts`.
 - **ESM Node / Jest / source**: sync fallback (worker paths do not resolve)
 - **Browser**: sync only (no worker bundles)
 
-**Worker failure semantics:** timeout (120s) → **`ClusterLockValidationTimeoutError`** (HTTP **504** in obol-api); worker crash / missing file → sync fallback (`null`). See plan doc.
+**Worker failure semantics:** whole-lock timeout (120s) or per-chunk BLS timeout (60s) → **`ClusterLockValidationTimeoutError`** (HTTP **504** in obol-api); worker crash / missing file → sync fallback (`null`). See plan doc.
 
 **When changing validation logic**, read **`PARALLEL_VALIDATION_PLAN.md`** first.
 Key types: `BlsSignatureCheck` in `src/types.ts`. Deposit/builder flow:

--- a/PARALLEL_VALIDATION_PLAN.md
+++ b/PARALLEL_VALIDATION_PLAN.md
@@ -226,10 +226,18 @@ from validation throwing.
 |---|---|---|
 | Worker message valid / invalid | `true` / `false` resolve | Returned to caller (`true` / `false`) |
 | Worker **timeout** (120s) | **rejects** `ClusterLockValidationTimeoutError` | Propagates; HTTP APIs → **504** |
+| Nested **chunk worker timeout** (60s) inside validation worker | Posts `{ validationTimeoutMs: 60000 }` → parent **rejects** same error | Propagates; HTTP APIs → **504** |
 | Worker **error** or non-zero **exit** | `null` | Sync fallback on main thread |
 | Worker file not found | `null` | Sync fallback |
 
 Timeout rejects (does not resolve `false`) so gateways distinguish overload/slow crypto from bad signatures (**400**).
+
+Per-chunk timeouts (`runWorker` / `runWorkerAggregatePubkeys` in `parallelPool.ts`) throw
+`ClusterLockValidationTimeoutError(WORKER_TIMEOUT_MS)` instead of resolving `false`/`null`.
+`clusterLockValidationWorker.ts` forwards that to the main thread via `validationTimeoutMs`;
+`isValidClusterLock` re-throws rather than returning `false`.
+
+**HTTP consumers (e.g. obol-api):** catch `ClusterLockValidationTimeoutError` by `name` and respond with **504**, not **400**.
 
 ---
 

--- a/PARALLEL_VALIDATION_PLAN.md
+++ b/PARALLEL_VALIDATION_PLAN.md
@@ -239,6 +239,14 @@ Per-chunk timeouts (`runWorker` / `runWorkerAggregatePubkeys` in `parallelPool.t
 
 **HTTP consumers (e.g. obol-api):** catch `ClusterLockValidationTimeoutError` by `name` and respond with **504**, not **400**.
 
+### Concurrent validation cap (DoS mitigation)
+
+| Constant / env | Default | Purpose |
+|---|---|---|
+| `OBOL_SDK_MAX_CONCURRENT_LOCK_VALIDATIONS` | `2` | Max in-flight `validateClusterLock` calls per Node process (`0` = unlimited) |
+
+When at capacity, `validateClusterLock` throws `ClusterLockValidationBusyError` immediately (no queue). obol-api should map to **503**.
+
 ---
 
 ## Charon local testing (no ngrok)

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build:clean": "rm -rf ./dist",
     "build": "npm-run-all build:clean build:tsup",
     "build:tsup": "tsup && tsc -b ./tsconfig.types.json",
-    "test": "NODE_OPTIONS=--experimental-vm-modules jest test/**/**.spec.ts --testPathIgnorePatterns=test/sdk-package/",
+    "test": "NODE_OPTIONS=--experimental-vm-modules OBOL_SDK_MAX_CONCURRENT_LOCK_VALIDATIONS=0 jest test/**/**.spec.ts --testPathIgnorePatterns=test/sdk-package/",
     "generate-typedoc": "typedoc",
     "npm:publish": "npm publish --tag latest",
     "npm:publish:next": "npm publish --tag next",

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -41,13 +41,8 @@ export class UnsupportedChainError extends Error {
 }
 
 /**
- * Thrown when full lock validation (`validateClusterLock` worker path) exceeds
- * the worker time limit (large clusters). HTTP gateways should respond with
- * **504**; this is distinct from cryptographic failure (**false** → **400**).
- */
-/**
  * Thrown when {@link Client} is constructed with a baseUrl that is not an
- * an allowed Obol API base URL (see {@link ALLOWED_OBOL_API_BASE_URLS}).
+ * allowed Obol API base URL (see {@link ALLOWED_OBOL_API_BASE_URLS}).
  */
 export class InvalidBaseUrlError extends Error {
   name = 'InvalidBaseUrlError';
@@ -58,11 +53,17 @@ export class InvalidBaseUrlError extends Error {
   }
 }
 
+/**
+ * Thrown when lock validation exceeds a worker time limit (large clusters).
+ * HTTP gateways should respond with **504**; distinct from crypto failure
+ * (`validateClusterLock` returning **false** → **400**).
+ */
 export class ClusterLockValidationTimeoutError extends Error {
   name = 'ClusterLockValidationTimeoutError';
 
   /**
-   * @param timeoutMs - Same value as SDK whole-lock validation worker timeout.
+   * @param timeoutMs - Worker deadline that was exceeded (`VALIDATION_WORKER_TIMEOUT_MS`
+   *   for the whole-lock worker, `WORKER_TIMEOUT_MS` for per-chunk BLS workers).
    */
   constructor(public readonly timeoutMs: number) {
     super(

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -72,3 +72,18 @@ export class ClusterLockValidationTimeoutError extends Error {
     Object.setPrototypeOf(this, ClusterLockValidationTimeoutError.prototype);
   }
 }
+
+/**
+ * Thrown when too many `validateClusterLock` calls are already in flight.
+ * HTTP gateways should respond with **503**; clients should retry with backoff.
+ */
+export class ClusterLockValidationBusyError extends Error {
+  name = 'ClusterLockValidationBusyError';
+
+  constructor(public readonly maxConcurrent: number) {
+    super(
+      `Too many cluster lock validations in progress (limit: ${maxConcurrent}). Retry later.`,
+    );
+    Object.setPrototypeOf(this, ClusterLockValidationBusyError.prototype);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,7 @@ export * from './verification/common.js';
 export * from './constants.js';
 export {
   ConflictError,
+  ClusterLockValidationBusyError,
   ClusterLockValidationTimeoutError,
   InvalidBaseUrlError,
   SignerRequiredError,

--- a/src/services.ts
+++ b/src/services.ts
@@ -20,9 +20,9 @@ import { validateClusterLockInWorker } from './verification/parallelPool.js';
  *   If omitted, falls back to the `RPC_MAINNET` / `RPC_HOODI` / etc. env vars.
  * @returns `true` if the lock is cryptographically valid; `false` if invalid
  *   (e.g. missing keys, invalid signatures, hash mismatches).
- * @throws `ClusterLockValidationTimeoutError` when whole-lock validation
- *   exceeds the SDK worker deadline (typically large clusters). HTTP APIs should map
- *   this to **504 Gateway Timeout**.
+ * @throws {@link ClusterLockValidationTimeoutError} when validation exceeds a
+ *   worker deadline (whole-lock or per-chunk BLS workers on large clusters).
+ *   HTTP APIs should map this to **504 Gateway Timeout**, not **400**.
  *
  * @example
  * ```typescript
@@ -38,11 +38,7 @@ export const validateClusterLock = async (
   lock: ClusterLock,
   safeRpcUrl?: SafeRpcUrl,
 ): Promise<boolean> => {
-  try {
-    const inWorker = await validateClusterLockInWorker(lock, safeRpcUrl);
-    if (inWorker !== null) return inWorker;
-    return await isValidClusterLock(lock, safeRpcUrl);
-  } catch (err: any) {
-    throw err;
-  }
+  const inWorker = await validateClusterLockInWorker(lock, safeRpcUrl);
+  if (inWorker !== null) return inWorker;
+  return await isValidClusterLock(lock, safeRpcUrl);
 };

--- a/src/services.ts
+++ b/src/services.ts
@@ -1,5 +1,6 @@
 import { type SafeRpcUrl, type ClusterLock } from './types.js';
 import { isValidClusterLock } from './verification/common.js';
+import { withLockValidationConcurrency } from './verification/validationConcurrency.js';
 import { validateClusterLockInWorker } from './verification/parallelPool.js';
 
 /**
@@ -23,6 +24,9 @@ import { validateClusterLockInWorker } from './verification/parallelPool.js';
  * @throws {@link ClusterLockValidationTimeoutError} when validation exceeds a
  *   worker deadline (whole-lock or per-chunk BLS workers on large clusters).
  *   HTTP APIs should map this to **504 Gateway Timeout**, not **400**.
+ * @throws {@link ClusterLockValidationBusyError} when concurrent validations exceed
+ *   `OBOL_SDK_MAX_CONCURRENT_LOCK_VALIDATIONS` (default **2**; set `0` for unlimited).
+ *   HTTP APIs should map this to **503 Service Unavailable**.
  *
  * @example
  * ```typescript
@@ -37,8 +41,9 @@ import { validateClusterLockInWorker } from './verification/parallelPool.js';
 export const validateClusterLock = async (
   lock: ClusterLock,
   safeRpcUrl?: SafeRpcUrl,
-): Promise<boolean> => {
-  const inWorker = await validateClusterLockInWorker(lock, safeRpcUrl);
-  if (inWorker !== null) return inWorker;
-  return await isValidClusterLock(lock, safeRpcUrl);
-};
+): Promise<boolean> =>
+  await withLockValidationConcurrency(async () => {
+    const inWorker = await validateClusterLockInWorker(lock, safeRpcUrl);
+    if (inWorker !== null) return inWorker;
+    return await isValidClusterLock(lock, safeRpcUrl);
+  });

--- a/src/verification/clusterLockValidationWorker.ts
+++ b/src/verification/clusterLockValidationWorker.ts
@@ -1,5 +1,6 @@
 // Runs isValidClusterLock in a worker thread so obol-api's main thread stays responsive.
 import { parentPort, workerData } from 'node:worker_threads';
+import { ClusterLockValidationTimeoutError } from '../errors.js';
 import type { ClusterLock, SafeRpcUrl } from '../types.js';
 import { isValidClusterLock } from './common.js';
 
@@ -14,7 +15,11 @@ if (parentPort) {
     .then(ok => {
       port.postMessage(ok);
     })
-    .catch(() => {
+    .catch(err => {
+      if (err instanceof ClusterLockValidationTimeoutError) {
+        port.postMessage({ validationTimeoutMs: err.timeoutMs });
+        return;
+      }
       port.postMessage(false);
     });
 }

--- a/src/verification/common.ts
+++ b/src/verification/common.ts
@@ -54,6 +54,7 @@ import {
   verifyDVV1X10,
 } from './v1.10.0.js';
 import { blsVerify } from '../blsUtils.js';
+import { ClusterLockValidationTimeoutError } from '../errors.js';
 
 // cluster-definition hash
 
@@ -631,6 +632,9 @@ export const isValidClusterLock = async (
     }
     return true;
   } catch (err) {
+    if (err instanceof ClusterLockValidationTimeoutError) {
+      throw err;
+    }
     return false;
   }
 };

--- a/src/verification/parallelPool.ts
+++ b/src/verification/parallelPool.ts
@@ -45,6 +45,23 @@ const MIN_KEYS_PER_WORKER_AGG = 100;
 const MIN_VALIDATORS_FOR_VALIDATION_WORKER = 50;
 const VALIDATION_WORKER_TIMEOUT_MS = 120_000;
 const WORKER_TIMEOUT_MS = 60_000;
+
+/** Posted from clusterLockValidationWorker when a nested BLS worker times out. */
+export type LockValidationWorkerTimeoutReply = {
+  validationTimeoutMs: number;
+};
+
+function isValidationTimeoutReply(
+  msg: unknown,
+): msg is LockValidationWorkerTimeoutReply {
+  return (
+    typeof msg === 'object' &&
+    msg !== null &&
+    'validationTimeoutMs' in msg &&
+    typeof (msg as LockValidationWorkerTimeoutReply).validationTimeoutMs ===
+      'number'
+  );
+}
 // Cap simultaneous workers (memory). Scales up for large jobs on multi-core hosts.
 const MAX_CONCURRENT_WORKERS_CAP = 8;
 
@@ -171,7 +188,7 @@ async function runWorkerAggregatePubkeys(
   workerFile: string,
   data: AggregatePubkeysInput,
 ): Promise<Uint8Array | null> {
-  return await new Promise(resolve => {
+  return await new Promise((resolve, reject) => {
     let settled = false;
     const worker = new wt.Worker(workerFile, { workerData: data });
     const finish = (result: Uint8Array | null): void => {
@@ -183,7 +200,12 @@ async function runWorkerAggregatePubkeys(
       resolve(result);
     };
     const timer = setTimeout(() => {
-      finish(null);
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      worker.terminate();
+      reject(new ClusterLockValidationTimeoutError(WORKER_TIMEOUT_MS));
     }, WORKER_TIMEOUT_MS);
     worker.once('message', (msg: unknown) => {
       finish(msg instanceof Uint8Array ? msg : null);
@@ -202,7 +224,7 @@ async function runWorker(
   workerFile: string,
   data: WorkerInput,
 ): Promise<boolean> {
-  return await new Promise(resolve => {
+  return await new Promise((resolve, reject) => {
     let settled = false;
     const worker = new wt.Worker(workerFile, { workerData: data });
     const finish = (result: boolean): void => {
@@ -214,7 +236,12 @@ async function runWorker(
       resolve(result);
     };
     const timer = setTimeout(() => {
-      finish(false);
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      worker.terminate();
+      reject(new ClusterLockValidationTimeoutError(WORKER_TIMEOUT_MS));
     }, WORKER_TIMEOUT_MS);
     worker.once('message', (msg: unknown) => {
       finish(msg === true);
@@ -445,6 +472,17 @@ export async function validateClusterLockInWorker(
       resolve(result);
     };
     worker.once('message', (msg: unknown) => {
+      if (isValidationTimeoutReply(msg)) {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        worker.terminate();
+        reject(
+          new ClusterLockValidationTimeoutError(msg.validationTimeoutMs),
+        );
+        return;
+      }
       finish(msg === true);
     });
     worker.once('error', () => {

--- a/src/verification/parallelPool.ts
+++ b/src/verification/parallelPool.ts
@@ -478,9 +478,7 @@ export async function validateClusterLockInWorker(
         clearTimeout(timer);
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         worker.terminate();
-        reject(
-          new ClusterLockValidationTimeoutError(msg.validationTimeoutMs),
-        );
+        reject(new ClusterLockValidationTimeoutError(msg.validationTimeoutMs));
         return;
       }
       finish(msg === true);

--- a/src/verification/validationConcurrency.ts
+++ b/src/verification/validationConcurrency.ts
@@ -1,0 +1,45 @@
+import { ClusterLockValidationBusyError } from '../errors.js';
+
+/**
+ * Max in-flight `validateClusterLock` calls per process.
+ * `0` = unlimited (e.g. tests: `OBOL_SDK_MAX_CONCURRENT_LOCK_VALIDATIONS=0`).
+ * Default `2` — tune via env for host CPU (obol-api should set in `.env`).
+ */
+export function getMaxConcurrentLockValidations(): number {
+  const raw = process.env.OBOL_SDK_MAX_CONCURRENT_LOCK_VALIDATIONS;
+  if (raw === '0') return 0;
+  if (raw !== undefined && raw !== '') {
+    const n = Number.parseInt(raw, 10);
+    if (Number.isFinite(n) && n > 0) return n;
+  }
+  return 2;
+}
+
+let activeValidations = 0;
+
+/**
+ * Limits parallel lock validation CPU/worker usage process-wide.
+ * Rejects immediately when at capacity (no queue — avoids memory growth under flood).
+ */
+export async function withLockValidationConcurrency<T>(
+  fn: () => Promise<T>,
+): Promise<T> {
+  const max = getMaxConcurrentLockValidations();
+  if (max === 0) return await fn();
+
+  if (activeValidations >= max) {
+    throw new ClusterLockValidationBusyError(max);
+  }
+
+  activeValidations++;
+  try {
+    return await fn();
+  } finally {
+    activeValidations--;
+  }
+}
+
+/** @internal Test helper */
+export function resetLockValidationConcurrencyForTests(): void {
+  activeValidations = 0;
+}

--- a/src/verification/validationConcurrency.ts
+++ b/src/verification/validationConcurrency.ts
@@ -38,8 +38,3 @@ export async function withLockValidationConcurrency<T>(
     activeValidations--;
   }
 }
-
-/** @internal Test helper */
-export function resetLockValidationConcurrencyForTests(): void {
-  activeValidations = 0;
-}

--- a/test/client/methods.spec.ts
+++ b/test/client/methods.spec.ts
@@ -235,6 +235,9 @@ describe('Cluster Client without a signer', () => {
    *
    * Therefore, when these tests return true, it's a REAL validation result!
    */
+  const mainnetSafeRpcUrl =
+    process.env.RPC_MAINNET || 'https://ethereum-rpc.publicnode.com';
+
   test.each([
     { version: 'v1.10.0 solo', clusterLock: clusterLockSoloV1X10 },
     {
@@ -249,11 +252,16 @@ describe('Cluster Client without a signer', () => {
     {
       version: 'Cluster with safe address v1.10.0',
       clusterLock: clusterLockWithSafe,
+      // Mainnet Safe operator needs a live RPC; Jest does not load .env by default.
+      safeRpcUrl: mainnetSafeRpcUrl,
     },
   ])(
     "$version: 'should return true on verified cluster lock'",
-    async ({ clusterLock }) => {
-      const isValidLock: boolean = await validateClusterLock(clusterLock);
+    async ({ clusterLock, safeRpcUrl }) => {
+      const isValidLock: boolean = await validateClusterLock(
+        clusterLock,
+        safeRpcUrl,
+      );
       expect(isValidLock).toEqual(true);
     },
   );
@@ -262,11 +270,9 @@ describe('Cluster Client without a signer', () => {
     process.env.RPC_HOODI = undefined;
 
     // Mainnet cluster - fourth operator 0x4d6c432b7E2F326B4DDf524ea9E56649e5A7C298 is the Safe wallet
-    const safeRpcUrl =
-      process.env.RPC_MAINNET || 'https://ethereum-rpc.publicnode.com';
     const isValidLock: boolean = await validateClusterLock(
       clusterLockWithSafe,
-      safeRpcUrl,
+      mainnetSafeRpcUrl,
     );
     expect(isValidLock).toEqual(true);
   });

--- a/test/verification/validationConcurrency.spec.ts
+++ b/test/verification/validationConcurrency.spec.ts
@@ -1,0 +1,61 @@
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { ClusterLockValidationBusyError } from '../../src/errors.js';
+import {
+  getMaxConcurrentLockValidations,
+  resetLockValidationConcurrencyForTests,
+  withLockValidationConcurrency,
+} from '../../src/verification/validationConcurrency.js';
+
+describe('validationConcurrency', () => {
+  const prevEnv = process.env.OBOL_SDK_MAX_CONCURRENT_LOCK_VALIDATIONS;
+
+  beforeEach(() => {
+    resetLockValidationConcurrencyForTests();
+  });
+
+  afterEach(() => {
+    if (prevEnv === undefined) {
+      delete process.env.OBOL_SDK_MAX_CONCURRENT_LOCK_VALIDATIONS;
+    } else {
+      process.env.OBOL_SDK_MAX_CONCURRENT_LOCK_VALIDATIONS = prevEnv;
+    }
+    resetLockValidationConcurrencyForTests();
+  });
+
+  it('defaults to 2 concurrent validations', () => {
+    delete process.env.OBOL_SDK_MAX_CONCURRENT_LOCK_VALIDATIONS;
+    expect(getMaxConcurrentLockValidations()).toBe(2);
+  });
+
+  it('treats env 0 as unlimited', () => {
+    process.env.OBOL_SDK_MAX_CONCURRENT_LOCK_VALIDATIONS = '0';
+    expect(getMaxConcurrentLockValidations()).toBe(0);
+  });
+
+  it('rejects when at capacity', async () => {
+    process.env.OBOL_SDK_MAX_CONCURRENT_LOCK_VALIDATIONS = '1';
+
+    let releaseFirst!: () => void;
+    let entered!: () => void;
+    const slotHeld = new Promise<void>(resolve => {
+      entered = resolve;
+    });
+
+    const first = withLockValidationConcurrency(async () => {
+      entered();
+      await new Promise<void>(resolve => {
+        releaseFirst = resolve;
+      });
+      return 'a';
+    });
+
+    await slotHeld;
+
+    await expect(
+      withLockValidationConcurrency(async () => 'b'),
+    ).rejects.toBeInstanceOf(ClusterLockValidationBusyError);
+
+    releaseFirst();
+    await expect(first).resolves.toBe('a');
+  });
+});

--- a/test/verification/validationConcurrency.spec.ts
+++ b/test/verification/validationConcurrency.spec.ts
@@ -1,17 +1,12 @@
-import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import { describe, it, expect, afterEach } from '@jest/globals';
 import { ClusterLockValidationBusyError } from '../../src/errors.js';
 import {
   getMaxConcurrentLockValidations,
-  resetLockValidationConcurrencyForTests,
   withLockValidationConcurrency,
 } from '../../src/verification/validationConcurrency.js';
 
 describe('validationConcurrency', () => {
   const prevEnv = process.env.OBOL_SDK_MAX_CONCURRENT_LOCK_VALIDATIONS;
-
-  beforeEach(() => {
-    resetLockValidationConcurrencyForTests();
-  });
 
   afterEach(() => {
     if (prevEnv === undefined) {
@@ -19,7 +14,6 @@ describe('validationConcurrency', () => {
     } else {
       process.env.OBOL_SDK_MAX_CONCURRENT_LOCK_VALIDATIONS = prevEnv;
     }
-    resetLockValidationConcurrencyForTests();
   });
 
   it('defaults to 2 concurrent validations', () => {
@@ -49,13 +43,15 @@ describe('validationConcurrency', () => {
       return 'a';
     });
 
-    await slotHeld;
+    try {
+      await slotHeld;
 
-    await expect(
-      withLockValidationConcurrency(async () => 'b'),
-    ).rejects.toBeInstanceOf(ClusterLockValidationBusyError);
-
-    releaseFirst();
-    await expect(first).resolves.toBe('a');
+      await expect(
+        withLockValidationConcurrency(async () => 'b'),
+      ).rejects.toBeInstanceOf(ClusterLockValidationBusyError);
+    } finally {
+      releaseFirst?.();
+      await first;
+    }
   });
 });

--- a/test/verification/validationTimeout.spec.ts
+++ b/test/verification/validationTimeout.spec.ts
@@ -1,0 +1,33 @@
+import { jest, describe, it, expect } from '@jest/globals';
+import { ClusterLockValidationTimeoutError } from '../../src/errors.js';
+
+describe('ClusterLockValidationTimeoutError', () => {
+  it('carries timeoutMs for gateway mapping (504)', () => {
+    const err = new ClusterLockValidationTimeoutError(60_000);
+    expect(err.name).toBe('ClusterLockValidationTimeoutError');
+    expect(err.timeoutMs).toBe(60_000);
+    expect(err.message).toContain('60000');
+  });
+});
+
+describe('validateClusterLock timeout propagation', () => {
+  it('re-throws ClusterLockValidationTimeoutError from the worker path', async () => {
+    const timeoutErr = new ClusterLockValidationTimeoutError(120_000);
+    await jest.unstable_mockModule(
+      '../../src/verification/parallelPool.js',
+      () => ({
+        validateClusterLockInWorker: jest
+          .fn<() => Promise<boolean | null>>()
+          .mockRejectedValue(timeoutErr),
+        verifySharesBinding: jest.fn(),
+        verifyBlsChecksParallel: jest.fn(),
+        verifyBatchParallel: jest.fn(),
+        verifyAggregateParallel: jest.fn(),
+      }),
+    );
+    const { validateClusterLock } = await import('../../src/services.js');
+    await expect(
+      validateClusterLock({ distributed_validators: [] } as never),
+    ).rejects.toBe(timeoutErr);
+  });
+});

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -5,5 +5,6 @@
       "declaration": true,
       "emitDeclarationOnly": true,
       "skipLibCheck": true
-    }
+    },
+    "exclude": ["node_modules", "dist", "test", "test/sdk-package", "test/nextjs-test-app"]
   }


### PR DESCRIPTION
## obol-sdk — PR summary

**Branch:** `Hanan/worker-timeout`

### Summary

- **Fix validation timeouts mapping:** Per-chunk BLS worker timeouts no longer resolve as `false` (which APIs treated as **400** invalid lock). They now throw `ClusterLockValidationTimeoutError` so gateways can respond with **504 Gateway Timeout**.
- **Propagate timeouts end-to-end:** Worker thread reports timeout to the parent pool; `common.ts` re-throws instead of swallowing; documented for HTTP consumers in `PARALLEL_VALIDATION_PLAN.md` and `CHANGELOG.md`.
- **Limit concurrent validations (DoS mitigation):** New process-wide cap on in-flight `validateClusterLock` calls (default **2**, env `OBOL_SDK_MAX_CONCURRENT_LOCK_VALIDATIONS`, `0` = unlimited). Throws `ClusterLockValidationBusyError` for hosts to map to **503** (no queue, to avoid memory growth under flood).
- **Exports & tests:** Export `ClusterLockValidationBusyError`; Jest runs with unlimited concurrency; add `validationTimeout` and `validationConcurrency` specs; exclude `test/` from types emit.

### Test plan

- [x] `yarn test` — 159 tests pass
- [ ] Manual: validate a large lock via obol-api (or direct SDK) and confirm worker timeout returns **504**, not **400**
- [ ] Manual: run 3+ parallel `validateClusterLock` with cap `2` and confirm third call throws `ClusterLockValidationBusyError`
- [ ] After merge: publish SDK and bump obol-api (see obol-api PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added concurrency limiting for cluster lock validation via `OBOL_SDK_MAX_CONCURRENT_LOCK_VALIDATIONS` environment variable (default: 2); returns 503 error when limit is reached.

* **Bug Fixes**
  * Per-chunk BLS worker timeouts now properly return 504 timeout errors instead of 400 validation errors.

* **Documentation**
  * Updated error documentation and architecture planning to clarify lock validation timeout behavior.

* **Tests**
  * Added test coverage for validation concurrency limits and timeout error propagation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ObolNetwork/obol-sdk/pull/212?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->