### PR TITLE
fix: raise lock validation worker timeouts for large clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file. Dates are displayed in UTC.
 
+#### Unreleased
+
+- fix: raise lock validation worker timeouts for large clusters on slow CPUs (per-chunk 180s, whole-lock 300s)
+
 #### [v2.12.4](https://github.com/ObolNetwork/obol-sdk/compare/v2.12.3...v2.12.4)
 
 - Hanan/worker timeout [`#214`](https://github.com/ObolNetwork/obol-sdk/pull/214)

--- a/PARALLEL_VALIDATION_PLAN.md
+++ b/PARALLEL_VALIDATION_PLAN.md
@@ -171,8 +171,8 @@ charon --publish --publish-address http://localhost:3001/v1
 | `MIN_KEYS_PER_WORKER_AGG` | 100 | Keys per worker when aggregating pubkeys |
 | `MAX_WORKERS` | 8 | Chunk count cap |
 | `MAX_CONCURRENT_WORKERS_CAP` | 8 | In-flight worker cap (memory) |
-| `VALIDATION_WORKER_TIMEOUT_MS` | 120_000 | Whole-lock worker timeout |
-| `WORKER_TIMEOUT_MS` | 60_000 | Per chunk worker timeout |
+| `VALIDATION_WORKER_TIMEOUT_MS` | 300_000 | Whole-lock worker timeout |
+| `WORKER_TIMEOUT_MS` | 180_000 | Per chunk worker timeout |
 
 ---
 
@@ -225,8 +225,8 @@ from validation throwing.
 | Event | Result | `validateClusterLock` behavior |
 |---|---|---|
 | Worker message valid / invalid | `true` / `false` resolve | Returned to caller (`true` / `false`) |
-| Worker **timeout** (120s) | **rejects** `ClusterLockValidationTimeoutError` | Propagates; HTTP APIs → **504** |
-| Nested **chunk worker timeout** (60s) inside validation worker | Posts `{ validationTimeoutMs: 60000 }` → parent **rejects** same error | Propagates; HTTP APIs → **504** |
+| Worker **timeout** (300s) | **rejects** `ClusterLockValidationTimeoutError` | Propagates; HTTP APIs → **504** |
+| Nested **chunk worker timeout** (180s) inside validation worker | Posts `{ validationTimeoutMs: 180000 }` → parent **rejects** same error | Propagates; HTTP APIs → **504** |
 | Worker **error** or non-zero **exit** | `null` | Sync fallback on main thread |
 | Worker file not found | `null` | Sync fallback |
 

--- a/src/verification/parallelPool.ts
+++ b/src/verification/parallelPool.ts
@@ -39,12 +39,11 @@ const MIN_VALIDATORS_PER_WORKER = 25;
 const MIN_PAIRS_PER_WORKER = 50;
 const MIN_PARALLEL_AGGREGATE_KEYS = 400;
 const MIN_KEYS_PER_WORKER_AGG = 100;
-// Hard ceiling so a stuck worker can't leak past obol-api's HTTP timeout.
-// Biggest legitimate batch (~1000 pairs) finishes in ~3s on the bench; 60s
-// is conservative enough to never false-trip on real input.
+// Hard ceiling so a stuck worker can't leak past obol-api / ingress timeouts.
+// Bench ~3s per chunk on fast CPU; dev pods (~500m) need more headroom for ~1k DVs.
 const MIN_VALIDATORS_FOR_VALIDATION_WORKER = 50;
-const VALIDATION_WORKER_TIMEOUT_MS = 120_000;
-const WORKER_TIMEOUT_MS = 60_000;
+const VALIDATION_WORKER_TIMEOUT_MS = 300_000;
+const WORKER_TIMEOUT_MS = 180_000;
 
 /** Posted from clusterLockValidationWorker when a nested BLS worker times out. */
 export type LockValidationWorkerTimeoutReply = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased lock validation worker timeouts to improve reliability for large clusters on slower CPUs (300s whole-lock validation, 180s per-chunk).

* **Documentation**
  * Updated validation documentation to reflect new timeout thresholds.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ObolNetwork/obol-sdk/pull/216?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->