### PR TITLE
fix: normalize operator addresses before uniqueness check

### DIFF
--- a/src/ajv.ts
+++ b/src/ajv.ts
@@ -83,7 +83,7 @@ const validateUniqueAddresses = (
     return false;
   }
 
-  const addresses = operators.map(op => op.address);
+  const addresses = operators.map(op => op.address.toLowerCase());
   const uniqueAddresses = new Set(addresses);
   const isUnique = uniqueAddresses.size === addresses.length;
   return isUnique;


### PR DESCRIPTION
## Summary

- Fixes case-sensitive operator uniqueness bypass in `validateUniqueAddresses` (`src/ajv.ts`) by lowercasing addresses before `Set` comparison.
- Without this, the same Ethereum address with different casing (e.g. `0xAbCd...` vs `0xabcd...`) could pass client-side validation as two distinct operators.

## Context

Reported via bug bounty (OBL-01). The server-side API already normalizes via `getAddress()` and the `updateClusterDef` flow blocks duplicate operators from completing DKG, so this was not exploitable end-to-end. Applied as defense-in-depth.

## Test plan

- [ ] Verify existing tests pass (`yarn test`)
- [ ] Confirm that operators with same address but different casing are now rejected by `validatePayload` with `definitionSchema`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Address validation now correctly identifies duplicate addresses regardless of capitalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->