### PR TITLE
fix: add hex pattern validation to operator address in definitionSchema

### DIFF
--- a/src/schema.ts
+++ b/src/schema.ts
@@ -27,7 +27,7 @@ export const definitionSchema = {
         properties: {
           address: {
             type: 'string',
-            pattern: '^0x[a-fA-F0-9]{40}$',
+            pattern: '^(|0x[a-fA-F0-9]{40})$',
           },
         },
         required: ['address'],

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -214,7 +214,7 @@ export const ovmTotalSplitPayloadSchema = {
         properties: {
           address: {
             type: 'string',
-            pattern: '^(|0x[a-fA-F0-9]{40})$',
+            pattern: '^0x[a-fA-F0-9]{40}$',
           },
           percentAllocation: { type: 'number' },
         },

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -27,6 +27,7 @@ export const definitionSchema = {
         properties: {
           address: {
             type: 'string',
+            pattern: '^0x[a-fA-F0-9]{40}$',
           },
         },
         required: ['address'],

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -214,7 +214,7 @@ export const ovmTotalSplitPayloadSchema = {
         properties: {
           address: {
             type: 'string',
-            pattern: '^0x[a-fA-F0-9]{40}$',
+            pattern: '^(|0x[a-fA-F0-9]{40})$',
           },
           percentAllocation: { type: 'number' },
         },


### PR DESCRIPTION
## Summary

- Adds `pattern: '^0x[a-fA-F0-9]{40}$'` to operator `address` in `definitionSchema`, matching the validation already applied to validator addresses, splitter recipients, and every other address field in the schema.
- Without this, non-hex strings like `0xGGGG...` pass the SDK's AJV validation (only a length check existed via `validateUniqueAddresses`). The obol-api server-side `@IsEthereumAddress()` + `getAddress()` guards catch these before storage, so the practical impact is low.

## Test plan

- [ ] Existing tests pass (`npm test`)
- [ ] Verify that `createClusterDefinition` with a non-hex operator address (e.g. `0xGGGG...GGGG`) now throws a validation error from the SDK before hitting the API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Address validation has been relaxed to permit empty values alongside valid hexadecimal addresses. This change applies to operator and principal recipient address fields, enabling more flexible input handling in applicable workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->