### PR TITLE
fix: guard against undefined RPC provider in Safe signature validation

### DIFF
--- a/src/verification/signature-validator.ts
+++ b/src/verification/signature-validator.ts
@@ -82,6 +82,9 @@ export const validateSmartContractSignature = async ({
 }): Promise<boolean> => {
   try {
     const safeProvider = safeRpcUrl ?? PROVIDER_MAP[chainId];
+    if (!safeProvider || safeProvider === 'undefined') {
+      throw new Error(`No RPC provider configured for chain ${chainId}`);
+    }
 
     const protocolKit = await Safe.init({
       provider: safeProvider,

--- a/src/verification/signature-validator.ts
+++ b/src/verification/signature-validator.ts
@@ -39,7 +39,10 @@ export const validateAddressSignature = async ({
       }
     }
     return validateEOASignature({ token, data, address });
-  } catch (error) {
+  } catch (error: any) {
+    console.warn(
+      `Smart contract signature validation failed, falling back to EOA: ${error.message}`,
+    );
     return validateEOASignature({ token, data, address });
   }
 };


### PR DESCRIPTION
## Summary

- `validateSmartContractSignature` now rejects the `"undefined"` string (produced by `PROVIDER_MAP` template literals when RPC env vars are unset) before passing it to `Safe.init()`, matching the existing guard in `getProvider()`.
- Hardens against a configuration-dependent DoS where valid Safe-signed cluster locks are rejected because the fallback RPC URL is the literal string `"undefined"`.

## Context

Reported via bug bounty (OBL-08, Low severity). When `RPC_MAINNET` / `RPC_HOODI` etc. are not set, `PROVIDER_MAP[chainId]` evaluates to the string `"undefined"` rather than `undefined`. `getProvider()` already checks for this; `validateSmartContractSignature` did not.

## Test plan

- [ ] `npm run build` passes
- [ ] `npm test` passes
- [ ] Manual: unset `RPC_MAINNET`, call `validateSmartContractSignature` with `chainId=1` and no `safeRpcUrl` — should throw `"No RPC provider configured for chain 1"` instead of passing `"undefined"` to Safe SDK