### PR TITLE
Reject cluster definition and lock validation below schema v1.10.0.

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -124,6 +124,9 @@ export const DKG_ALGORITHM = 'default';
 
 export const CONFIG_VERSION = 'v1.10.0';
 
+/** Minimum cluster definition / lock schema version accepted when posting to the API. */
+export const MIN_SUPPORTED_CLUSTER_VERSION = 'v1.10.0';
+
 export const SDK_VERSION = pjson.version;
 
 export const DOMAIN_APPLICATION_BUILDER = '00000001';

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import {
   Domain,
   DKG_ALGORITHM,
   CONFIG_VERSION,
+  MIN_SUPPORTED_CLUSTER_VERSION,
   OperatorConfigHashSigningTypes,
   EnrSigningTypes,
   TERMS_AND_CONDITIONS_VERSION,
@@ -35,7 +36,10 @@ import {
   type ProviderType,
   type SignerType,
 } from './types.js';
-import { clusterConfigOrDefinitionHash } from './verification/common.js';
+import {
+  clusterConfigOrDefinitionHash,
+  isSupportedClusterVersion,
+} from './verification/common.js';
 import { validatePayload } from './ajv.js';
 import {
   definitionSchema,
@@ -686,6 +690,12 @@ export class Client extends Base {
       operatorPayload,
       operatorPayloadSchema,
     );
+
+    if (!isSupportedClusterVersion(validatedPayload.version)) {
+      throw new Error(
+        `Unsupported version ${validatedPayload.version}. Minimum supported version is ${MIN_SUPPORTED_CLUSTER_VERSION}.`,
+      );
+    }
 
     try {
       const address = await this.signer.getAddress();

--- a/src/verification/common.ts
+++ b/src/verification/common.ts
@@ -28,6 +28,7 @@ import {
   DOMAIN_DEPOSIT,
   DefinitionFlow,
   GENESIS_VALIDATOR_ROOT,
+  MIN_SUPPORTED_CLUSTER_VERSION,
   signCreatorConfigHashPayload,
   signEnrPayload,
   signOperatorConfigHashPayload,
@@ -594,11 +595,20 @@ export const hasUniqueDistributedKeys = (clusterLock: ClusterLock): boolean => {
   return new Set(dvKeys).size === dvKeys.length;
 };
 
+export const isSupportedClusterVersion = (version: string): boolean =>
+  semver.gte(version, MIN_SUPPORTED_CLUSTER_VERSION);
+
 export const isValidClusterLock = async (
   clusterLock: ClusterLock,
   safeRpcUrl?: SafeRpcUrl,
 ): Promise<boolean> => {
   try {
+    if (
+      !isSupportedClusterVersion(clusterLock.cluster_definition.version)
+    ) {
+      return false;
+    }
+
     const definitionType = definitionFlow(clusterLock.cluster_definition);
     if (definitionType == null) {
       return false;

--- a/test/client/methods.spec.ts
+++ b/test/client/methods.spec.ts
@@ -240,10 +240,6 @@ describe('Cluster Client without a signer', () => {
 
   test.each([
     { version: 'v1.10.0 solo', clusterLock: clusterLockSoloV1X10 },
-    {
-      version: 'null deposit_amounts v1.8.0',
-      clusterLock: nullDepositAmountsClusterLockV1X8,
-    },
     { version: 'v1.10.0', clusterLock: clusterLockV1X10 },
     {
       version: 'v1.10.0 with compounding withdrawals',
@@ -275,6 +271,13 @@ describe('Cluster Client without a signer', () => {
       mainnetSafeRpcUrl,
     );
     expect(isValidLock).toEqual(true);
+  });
+
+  test('validateClusterLock returns false for cluster lock versions below v1.10.0', async () => {
+    const isValidLock: boolean = await validateClusterLock(
+      nullDepositAmountsClusterLockV1X8,
+    );
+    expect(isValidLock).toEqual(false);
   });
 
   test('validateCluster should return false for cluster with null deposit_amounts and incorrect partial_deposits', async () => {

--- a/test/sdk-package/cluster.spec.ts
+++ b/test/sdk-package/cluster.spec.ts
@@ -472,10 +472,6 @@ describe('Poll Cluster Lock', () => {
       version: 'Cluster with safe address v1.10.0',
       clusterLock: clusterLockWithSafe,
     },
-    {
-      version: 'null deposit_amounts v1.8.0',
-      clusterLock: nullDepositAmountsClusterLockV1X8,
-    },
     { version: 'v1.10.0', clusterLock: clusterLockV1X10 },
   ])(
     "$version: 'should return true on verified cluster lock'",


### PR DESCRIPTION
Align SDK publish/accept paths with the API by requiring v1.10.0+ for operator joins and validateClusterLock.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation to reject cluster definitions and locks below version v1.10.0.
  * Unsupported versions now return a clear error indicating the minimum supported version.

* **Bug Fixes**
  * Prevented outdated cluster locks from passing validation.

* **Tests**
  * Added coverage confirming that cluster locks below v1.10.0 are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->