### PR TITLE
fix: support Safe wallets in EOA withdrawal/exit and batch deposit

### DIFF
--- a/src/eoa/eoaHelpers.ts
+++ b/src/eoa/eoaHelpers.ts
@@ -1,7 +1,18 @@
 import { ETHER_TO_GWEI } from '../constants.js';
 import { type SignerType } from '../types.js';
-import { Contract } from 'ethers';
+import { Contract, type JsonRpcSigner } from 'ethers';
 import { BatchDepositContract } from '../abi/BatchDeposit.js';
+import {
+  isContractWalletSigner,
+  submitViaContractWalletAndWait,
+} from '../splits/splitHelpers.js';
+
+// Safe wallets return an internal safeTxHash from sendTransaction, so
+// tx.wait() hangs forever (the hash never appears on-chain). Contract-wallet
+// signers submit unchecked and resolve via the Safe's ExecutionSuccess log.
+const isSafeLikeSigner = async (signer: SignerType): Promise<boolean> =>
+  'sendUncheckedTransaction' in signer &&
+  (await isContractWalletSigner(signer));
 
 /**
  * Helper function to submit withdrawal request for EOA
@@ -32,6 +43,16 @@ export async function submitEOAWithdrawalRequest({
 
   const amountInGwei = BigInt(Math.floor(Number(allocation) * ETHER_TO_GWEI));
   const data = `0x${pubkey.slice(2)}${amountInGwei.toString(16).padStart(16, '0')}`;
+
+  if (await isSafeLikeSigner(signer)) {
+    const txHash = await submitViaContractWalletAndWait({
+      signer: signer as JsonRpcSigner,
+      to: withdrawalContractAddress,
+      data,
+      value: BigInt(requiredFee),
+    });
+    return { txHash };
+  }
 
   const tx = await signer.sendTransaction({
     to: withdrawalContractAddress,
@@ -74,6 +95,8 @@ export async function submitEOABatchDeposit({
     signer,
   );
 
+  const useContractWallet = await isSafeLikeSigner(signer);
+
   const BATCH_SIZE = 500;
   const txHashes: string[] = [];
 
@@ -97,6 +120,20 @@ export async function submitEOABatchDeposit({
         amount: BigInt(deposit.amount),
       }));
 
+      if (useContractWallet) {
+        const txHash = await submitViaContractWalletAndWait({
+          signer: signer as JsonRpcSigner,
+          to: batchDepositContractAddress,
+          data: batchDepositContract.interface.encodeFunctionData(
+            'batchDeposit',
+            [depositData],
+          ),
+          value: totalValue,
+        });
+        txHashes.push(txHash);
+        continue;
+      }
+
       // Execute batch deposit for this batch
       const tx = await batchDepositContract.batchDeposit(depositData, {
         value: totalValue,
@@ -109,6 +146,10 @@ export async function submitEOABatchDeposit({
     }
     return { txHashes };
   } catch (error: any) {
+    // Keep the actionable Safe timeout message ("retry to continue").
+    if (error instanceof Error && error.message.includes('Safe transaction')) {
+      throw error;
+    }
     throw new Error("Failed to submit batch deposit'}");
   }
 }

--- a/src/eoa/eoaHelpers.ts
+++ b/src/eoa/eoaHelpers.ts
@@ -2,6 +2,7 @@ import { ETHER_TO_GWEI } from '../constants.js';
 import { type SignerType } from '../types.js';
 import { Contract, type JsonRpcSigner } from 'ethers';
 import { BatchDepositContract } from '../abi/BatchDeposit.js';
+import { SignerRequiredError } from '../errors.js';
 import {
   isContractWalletSigner,
   submitViaContractWalletAndWait,
@@ -10,9 +11,16 @@ import {
 // Safe wallets return an internal safeTxHash from sendTransaction, so
 // tx.wait() hangs forever (the hash never appears on-chain). Contract-wallet
 // signers submit unchecked and resolve via the Safe's ExecutionSuccess log.
-const isSafeLikeSigner = async (signer: SignerType): Promise<boolean> =>
-  'sendUncheckedTransaction' in signer &&
-  (await isContractWalletSigner(signer));
+// This is the first dereference on both write flows, so it guards the signer.
+const isSafeLikeSigner = async (signer: SignerType): Promise<boolean> => {
+  if (!signer) {
+    throw new SignerRequiredError('submitEOATransaction');
+  }
+  return (
+    'sendUncheckedTransaction' in signer &&
+    (await isContractWalletSigner(signer))
+  );
+};
 
 /**
  * Helper function to submit withdrawal request for EOA

--- a/src/index.ts
+++ b/src/index.ts
@@ -578,6 +578,12 @@ export class Client extends Base {
    * - Creating a duplicate cluster throws a {@link ConflictError}.
    *
    * @param newCluster - The cluster configuration payload.
+   * @param version - Cluster definition version to create. Defaults to
+   *   {@link CONFIG_VERSION} (the latest). Pass an earlier version (e.g.
+   *   `'v1.10.0'`) to create clusters compatible with a charon version that
+   *   does not yet support the latest schema — the DKG nodes must run a charon
+   *   release that supports the chosen version. Must be a charon-supported
+   *   version string.
    * @returns The `config_hash` string that uniquely identifies this cluster definition.
    * @throws {SignerRequiredError} If no signer was provided.
    * @throws {ConflictError} If an identical cluster definition already exists.
@@ -595,7 +601,10 @@ export class Client extends Base {
    * console.log("Cluster created:", configHash);
    * ```
    */
-  async createClusterDefinition(newCluster: ClusterPayload): Promise<string> {
+  async createClusterDefinition(
+    newCluster: ClusterPayload,
+    version: string = CONFIG_VERSION,
+  ): Promise<string> {
     if (!this.signer) {
       throw new SignerRequiredError('createClusterDefinition');
     }
@@ -609,7 +618,7 @@ export class Client extends Base {
       ...validatedCluster,
       fork_version: this.fork_version,
       dkg_algorithm: DKG_ALGORITHM,
-      version: CONFIG_VERSION,
+      version,
       uuid: uuidv4(),
       timestamp: new Date().toISOString(),
       threshold: Math.ceil((2 * validatedCluster.operators.length) / 3),

--- a/src/splits/splitHelpers.ts
+++ b/src/splits/splitHelpers.ts
@@ -27,6 +27,7 @@ import { CHAIN_CONFIGURATION, ETHER_TO_GWEI } from '../constants.js';
 import { splitV2FactoryAbi } from '../abi/splitV2FactoryAbi.js';
 import { MultiCall3Contract } from '../abi/Multicall3.js';
 import { isContractAvailable } from '../utils.js';
+import { SignerRequiredError } from '../errors.js';
 
 const splitMainContractInterface = new Interface(splitMainEthereumAbi);
 const owrFactoryContractInterface = new Interface(OWRFactoryContract.abi);
@@ -66,6 +67,9 @@ export const extractOvmAddressFromReceipt = (
 export const isContractWalletSigner = async (
   signer: SignerType,
 ): Promise<boolean> => {
+  if (!signer) {
+    throw new SignerRequiredError('isContractWalletSigner');
+  }
   if (!signer.provider || !('sendUncheckedTransaction' in signer)) {
     return false;
   }
@@ -232,6 +236,9 @@ export const submitViaContractWalletAndWait = async ({
   value?: bigint;
   timeoutMs?: number;
 }): Promise<string> => {
+  if (!signer) {
+    throw new SignerRequiredError('submitViaContractWalletAndWait');
+  }
   const provider = signer.provider;
   const safeAddress = await signer.getAddress();
   const filter = {

--- a/src/splits/splitHelpers.ts
+++ b/src/splits/splitHelpers.ts
@@ -63,7 +63,9 @@ export const extractOvmAddressFromReceipt = (
 
 // True when the signer is a smart-contract wallet (e.g. a Safe) going through
 // a JSON-RPC connection. Local Wallet signers are always EOAs.
-const isContractWalletSigner = async (signer: SignerType): Promise<boolean> => {
+export const isContractWalletSigner = async (
+  signer: SignerType,
+): Promise<boolean> => {
   if (!signer.provider || !('sendUncheckedTransaction' in signer)) {
     return false;
   }
@@ -195,6 +197,120 @@ const submitViaContractWalletAndResolveOvm = async ({
         for (const ev of past) {
           const ovm = (ev as EventLog).args?.[0] as string | undefined;
           if (ovm) consider(ovm, ev.transactionHash);
+        }
+      })
+      .catch((err: Error) => {
+        settle(() => {
+          reject(err);
+        });
+      });
+  });
+};
+
+/**
+ * Submits an arbitrary transaction from a contract wallet (e.g. a Safe) and
+ * resolves the EXECUTED on-chain transaction hash. Safe wallets return an
+ * internal safeTxHash that never appears on-chain, so tx.wait() would hang
+ * forever; instead ethers watches the Safe's own ExecutionSuccess logs and
+ * resolves when one carries the wallet-returned hash (or when the wallet
+ * returned a real transaction hash, e.g. a 1-of-1 Safe).
+ *
+ * Used by flows that need no data out of the receipt (EOA withdrawal
+ * requests, batch deposits) — unlike OVM deployment, which additionally
+ * resolves the created contract address.
+ */
+export const submitViaContractWalletAndWait = async ({
+  signer,
+  to,
+  data,
+  value,
+  timeoutMs = SAFE_EXECUTION_TIMEOUT_MS,
+}: {
+  signer: JsonRpcSigner;
+  to: string;
+  data: string;
+  value?: bigint;
+  timeoutMs?: number;
+}): Promise<string> => {
+  const provider = signer.provider;
+  const safeAddress = await signer.getAddress();
+  const filter = {
+    address: safeAddress,
+    topics: [SAFE_EXECUTION_SUCCESS_TOPIC],
+  };
+  // Captured before submission so the backfill below cannot miss an
+  // execution mined before the wallet call returned (e.g. a 1-of-1 Safe).
+  const startBlock = await provider.getBlockNumber();
+
+  const matchesSubmission = (
+    log: { transactionHash?: string; topics: readonly string[]; data: string },
+    submittedHash: string,
+  ): boolean => {
+    if (log.transactionHash?.toLowerCase() === submittedHash.toLowerCase()) {
+      return true; // the wallet returned a real transaction hash
+    }
+    const loggedHash =
+      log.topics.length > 1 ? log.topics[1] : dataSlice(log.data, 0, 32);
+    return loggedHash?.toLowerCase() === submittedHash.toLowerCase();
+  };
+
+  return await new Promise<string>((resolve, reject) => {
+    let submittedHash: string | null = null;
+    let settled = false;
+
+    const settle = (finish: () => void): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      void provider.off(filter, listener);
+      finish();
+    };
+
+    const consider = (log: {
+      transactionHash?: string;
+      topics: readonly string[];
+      data: string;
+    }): void => {
+      // Before submission returns we cannot match; the backfill re-checks.
+      if (!submittedHash || settled) return;
+      if (matchesSubmission(log, submittedHash) && log.transactionHash) {
+        const executedHash = log.transactionHash;
+        settle(() => {
+          resolve(executedHash);
+        });
+      }
+    };
+
+    const listener = (log: {
+      transactionHash?: string;
+      topics: readonly string[];
+      data: string;
+    }): void => {
+      consider(log);
+    };
+
+    const timer = setTimeout(() => {
+      settle(() => {
+        reject(
+          new Error(
+            'Timed out waiting for the Safe transaction to be executed. Once all owners have signed and it executes, retry to continue.',
+          ),
+        );
+      });
+    }, timeoutMs);
+
+    void provider.on(filter, listener);
+    signer
+      .sendUncheckedTransaction({ to, data, ...(value ? { value } : {}) })
+      .then(async hash => {
+        submittedHash = hash;
+        // Backfill logs mined between startBlock and now.
+        const past = await provider.getLogs({
+          ...filter,
+          fromBlock: startBlock,
+        });
+        for (const log of past) {
+          consider(log);
         }
       })
       .catch((err: Error) => {

--- a/test/client/methods.spec.ts
+++ b/test/client/methods.spec.ts
@@ -11,7 +11,7 @@ import {
   nullDepositAmountsClusterLockV1X8,
   clusterLockSoloV1X10,
 } from '../fixtures.js';
-import { SDK_VERSION } from '../../src/constants.js';
+import { SDK_VERSION, CONFIG_VERSION } from '../../src/constants.js';
 import { Base } from '../../src/base.js';
 import { hasUniqueDistributedKeys } from '../../src/verification/common.js';
 import { clusterConfigOrDefinitionHash } from '../../src/verification/common.js';
@@ -61,6 +61,27 @@ describe('Cluster Client', () => {
     const configHash =
       await clientInstance.createClusterDefinition(clusterConfigV1X10);
     expect(configHash).toEqual(mockConfigHash);
+  });
+
+  test('createClusterDefinition stamps the requested version (default CONFIG_VERSION)', async () => {
+    const requestMock = jest
+      .fn()
+      .mockReturnValue(Promise.resolve({ config_hash: mockConfigHash }));
+    clientInstance['request'] = requestMock as never;
+
+    // Explicit older version (e.g. while charon prod is pre-v1.11).
+    await clientInstance.createClusterDefinition(clusterConfigV1X10, 'v1.10.0');
+    const explicitBody = JSON.parse(
+      (requestMock.mock.calls[0][1] as { body: string }).body,
+    );
+    expect(explicitBody.version).toEqual('v1.10.0');
+
+    // Omitting the arg defaults to the SDK's CONFIG_VERSION.
+    await clientInstance.createClusterDefinition(clusterConfigV1X10);
+    const defaultBody = JSON.parse(
+      (requestMock.mock.calls[1][1] as { body: string }).body,
+    );
+    expect(defaultBody.version).toEqual(CONFIG_VERSION);
   });
 
   test('acceptClusterDefinition should return cluster definition', async () => {

--- a/test/eoa/safeEoaHelpers.spec.ts
+++ b/test/eoa/safeEoaHelpers.spec.ts
@@ -1,0 +1,176 @@
+// @ts-nocheck
+import { jest } from '@jest/globals';
+import { AbiCoder, id } from 'ethers';
+import { submitViaContractWalletAndWait } from '../../src/splits/splitHelpers';
+import { submitEOAWithdrawalRequest } from '../../src/eoa/eoaHelpers';
+
+const SAFE_ADDRESS = '0xAbCdEf0123456789012345678901234567890AbC';
+const SAFE_TX_HASH = '0x' + 'aa'.repeat(32);
+const EXECUTED_TX_HASH = '0x' + 'ee'.repeat(32);
+const SUCCESS_TOPIC = id('ExecutionSuccess(bytes32,uint256)');
+const TARGET = '0x00000961Ef480Eb55e80D19ad83579A64c007002';
+
+const executionSuccessLog = (safeTxHash: string, indexed = true) =>
+  indexed
+    ? {
+        address: SAFE_ADDRESS,
+        transactionHash: EXECUTED_TX_HASH,
+        topics: [SUCCESS_TOPIC, safeTxHash],
+        data: '0x',
+      }
+    : {
+        address: SAFE_ADDRESS,
+        transactionHash: EXECUTED_TX_HASH,
+        topics: [SUCCESS_TOPIC],
+        data: AbiCoder.defaultAbiCoder().encode(
+          ['bytes32', 'uint256'],
+          [safeTxHash, 0],
+        ),
+      };
+
+const makeSafeSigner = ({
+  returnedHash = SAFE_TX_HASH,
+  pastLogs = [],
+  liveLog = null,
+}: {
+  returnedHash?: string;
+  pastLogs?: unknown[];
+  liveLog?: unknown;
+}) => {
+  let capturedListener: ((log: unknown) => void) | null = null;
+  const provider = {
+    getBlockNumber: jest.fn(async () => 100),
+    getCode: jest.fn(async () => '0xabcdef'), // contract wallet
+    getLogs: jest.fn(async () => pastLogs),
+    on: jest.fn(async (_filter, listener) => {
+      capturedListener = listener;
+      if (liveLog) {
+        // Deliver asynchronously like a real subscription.
+        setTimeout(() => capturedListener?.(liveLog), 5);
+      }
+    }),
+    off: jest.fn(async () => {}),
+  };
+  const signer = {
+    provider,
+    getAddress: jest.fn(async () => SAFE_ADDRESS),
+    sendUncheckedTransaction: jest.fn(async () => returnedHash),
+    sendTransaction: jest.fn(),
+  };
+  return { signer, provider };
+};
+
+describe('submitViaContractWalletAndWait', () => {
+  it('resolves the executed tx hash from a live ExecutionSuccess (indexed hash)', async () => {
+    const { signer } = makeSafeSigner({
+      liveLog: executionSuccessLog(SAFE_TX_HASH),
+    });
+
+    const txHash = await submitViaContractWalletAndWait({
+      signer,
+      to: TARGET,
+      data: '0x1234',
+      value: 1n,
+    });
+
+    expect(txHash).toBe(EXECUTED_TX_HASH);
+    expect(signer.sendUncheckedTransaction).toHaveBeenCalledWith({
+      to: TARGET,
+      data: '0x1234',
+      value: 1n,
+    });
+  });
+
+  it('resolves from a backfilled ExecutionSuccess (v1.3.0 data-word hash)', async () => {
+    const { signer } = makeSafeSigner({
+      pastLogs: [executionSuccessLog(SAFE_TX_HASH, false)],
+    });
+
+    const txHash = await submitViaContractWalletAndWait({
+      signer,
+      to: TARGET,
+      data: '0x1234',
+    });
+
+    expect(txHash).toBe(EXECUTED_TX_HASH);
+  });
+
+  it('resolves when the wallet returned a real tx hash (1-of-1 Safe)', async () => {
+    const log = {
+      ...executionSuccessLog('0x' + 'bb'.repeat(32)),
+      transactionHash: EXECUTED_TX_HASH,
+    };
+    const { signer } = makeSafeSigner({
+      returnedHash: EXECUTED_TX_HASH,
+      pastLogs: [log],
+    });
+
+    const txHash = await submitViaContractWalletAndWait({
+      signer,
+      to: TARGET,
+      data: '0x1234',
+    });
+
+    expect(txHash).toBe(EXECUTED_TX_HASH);
+  });
+
+  it('ignores another submission’s ExecutionSuccess and times out', async () => {
+    const { signer } = makeSafeSigner({
+      pastLogs: [executionSuccessLog('0x' + 'cc'.repeat(32))],
+    });
+
+    await expect(
+      submitViaContractWalletAndWait({
+        signer,
+        to: TARGET,
+        data: '0x1234',
+        timeoutMs: 50,
+      }),
+    ).rejects.toThrow('Timed out waiting for the Safe transaction');
+  });
+});
+
+describe('submitEOAWithdrawalRequest signer branching', () => {
+  it('uses the Safe path for contract-wallet signers (no tx.wait hang)', async () => {
+    const { signer } = makeSafeSigner({
+      liveLog: executionSuccessLog(SAFE_TX_HASH),
+    });
+
+    const { txHash } = await submitEOAWithdrawalRequest({
+      pubkey: '0x' + '11'.repeat(48),
+      allocation: 0,
+      withdrawalAddress: SAFE_ADDRESS,
+      withdrawalContractAddress: TARGET,
+      requiredFee: '1',
+      chainId: 560048,
+      signer,
+    });
+
+    expect(txHash).toBe(EXECUTED_TX_HASH);
+    expect(signer.sendTransaction).not.toHaveBeenCalled();
+  });
+
+  it('keeps the legacy sendTransaction + wait path for EOAs', async () => {
+    const wait = jest.fn(async () => ({ hash: EXECUTED_TX_HASH }));
+    const signer = {
+      provider: { getCode: jest.fn(async () => '0x') },
+      getAddress: jest.fn(async () => '0x1111111111111111111111111111111111111111'),
+      // No sendUncheckedTransaction => plain EOA signer.
+      sendTransaction: jest.fn(async () => ({ wait })),
+    };
+
+    const { txHash } = await submitEOAWithdrawalRequest({
+      pubkey: '0x' + '11'.repeat(48),
+      allocation: 0,
+      withdrawalAddress: '0x1111111111111111111111111111111111111111',
+      withdrawalContractAddress: TARGET,
+      requiredFee: '1',
+      chainId: 560048,
+      signer,
+    });
+
+    expect(txHash).toBe(EXECUTED_TX_HASH);
+    expect(signer.sendTransaction).toHaveBeenCalledTimes(1);
+    expect(wait).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/eoa/safeEoaHelpers.spec.ts
+++ b/test/eoa/safeEoaHelpers.spec.ts
@@ -3,6 +3,8 @@ import { jest } from '@jest/globals';
 import { AbiCoder, id } from 'ethers';
 import { submitViaContractWalletAndWait } from '../../src/splits/splitHelpers';
 import { submitEOAWithdrawalRequest } from '../../src/eoa/eoaHelpers';
+import { isContractWalletSigner } from '../../src/splits/splitHelpers';
+import { SignerRequiredError } from '../../src/errors';
 
 const SAFE_ADDRESS = '0xAbCdEf0123456789012345678901234567890AbC';
 const SAFE_TX_HASH = '0x' + 'aa'.repeat(32);
@@ -172,5 +174,27 @@ describe('submitEOAWithdrawalRequest signer branching', () => {
     expect(txHash).toBe(EXECUTED_TX_HASH);
     expect(signer.sendTransaction).toHaveBeenCalledTimes(1);
     expect(wait).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('signer guards (SignerRequiredError, not raw TypeError)', () => {
+  it('isContractWalletSigner throws SignerRequiredError on a nullish signer', async () => {
+    await expect(
+      isContractWalletSigner(null as unknown as never),
+    ).rejects.toBeInstanceOf(SignerRequiredError);
+  });
+
+  it('submitEOAWithdrawalRequest throws SignerRequiredError on a nullish signer', async () => {
+    await expect(
+      submitEOAWithdrawalRequest({
+        pubkey: '0x' + '11'.repeat(48),
+        allocation: 0,
+        withdrawalAddress: SAFE_ADDRESS,
+        withdrawalContractAddress: TARGET,
+        requiredFee: '1',
+        chainId: 560048,
+        signer: null as unknown as never,
+      }),
+    ).rejects.toBeInstanceOf(SignerRequiredError);
   });
 });

--- a/test/splits/splits.spec.ts
+++ b/test/splits/splits.spec.ts
@@ -27,6 +27,8 @@ await jest.unstable_mockModule('../../src/splits/splitHelpers.js', () => ({
   deployOVMAndSplitV2: jest.fn(),
   requestWithdrawalFromOVM: jest.fn(),
   depositOVM: jest.fn(),
+  isContractWalletSigner: jest.fn(async () => false),
+  submitViaContractWalletAndWait: jest.fn(),
 }));
 
 // Mock utils using unstable_mockModule


### PR DESCRIPTION
# Support Safe & Contract Wallet Transaction Submission

Safe wallets return an internal `safeTxHash` from `sendTransaction`, causing `tx.wait()` to poll a hash that never appears on-chain. As a result, the exit/deposit UI hangs indefinitely for Safe wallets with a threshold ≥ 2, even though the transaction executes successfully once all co-owners sign.

This change mirrors the Safe handling already implemented in OVM Deploy (v2.13.1), giving all Safe transaction flows a consistent mechanism.

## Changes

### New `submitViaContractWalletAndWait`

Introduced a new helper that:

- Submits transactions via `sendUncheckedTransaction()`
- Resolves the executed on-chain transaction hash by matching the Safe `ExecutionSuccess` event
- Supports both Safe versions:
  - **v1.4.1+**: `safeTxHash` is indexed
  - **v1.3.0**: `safeTxHash` is stored in the first data word
- Backfills events mined between the pre-submission block and the time submission returns
- Times out after **30 minutes** with a clear, actionable error message
- Immediately resolves if the wallet already returns a real transaction hash (e.g. 1-of-1 Safe)

> **Note:** Over HTTP/WalletConnect providers, ethers listens for these events via internal `eth_getLogs` polling rather than a true push subscription.

### Contract Wallet Support

- `submitEOAWithdrawalRequest()` and `submitEOABatchDeposit()` now use the new helper when the signer is detected as a contract wallet (`isContractWalletSigner`)
- The EOA execution path remains byte-for-byte unchanged

### API Compatibility

No API changes were required.

Return types remain:

- `{ txHash }`
- `{ txHashes }`

## Summary (CodeRabbit)

### New Features

- Added support for withdrawals and batch deposits through Safe and other contract wallets
- Transactions now return the executed on-chain transaction hash
- Safe execution events are monitored, including events mined before submission returns

### Bug Fixes

- Safe transaction timeouts now preserve a specific, actionable error message
- Standard EOA transaction behavior is unchanged

### Tests

Added coverage for:

- Safe transaction submission
- Event handling for both indexed and data-word `safeTxHash` formats
- 1-of-1 Safe real transaction hash resolution
- Timeout handling
- EOA compatibility

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Safe/contract-wallet–aware submission for withdrawals and batch deposits, returning the executed transaction hash after confirmed on-chain execution.
  * `createClusterDefinition` now supports an optional schema/version argument; the API request is stamped with that version (defaulting to the existing config version).
* **Bug Fixes**
  * Improved Safe transaction timeout/failure handling by preserving actionable error messages.
  * Added/expanded validation to throw clear errors when signer information is missing.
* **Tests**
  * Expanded test coverage for Safe execution-hash resolution, branching behavior, and version stamping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->