### PR TITLE
feat(createClusterDefinition): accept an optional version param

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -578,6 +578,12 @@ export class Client extends Base {
    * - Creating a duplicate cluster throws a {@link ConflictError}.
    *
    * @param newCluster - The cluster configuration payload.
+   * @param version - Cluster definition version to create. Defaults to
+   *   {@link CONFIG_VERSION} (the latest). Pass an earlier version (e.g.
+   *   `'v1.10.0'`) to create clusters compatible with a charon version that
+   *   does not yet support the latest schema — the DKG nodes must run a charon
+   *   release that supports the chosen version. Must be a charon-supported
+   *   version string.
    * @returns The `config_hash` string that uniquely identifies this cluster definition.
    * @throws {SignerRequiredError} If no signer was provided.
    * @throws {ConflictError} If an identical cluster definition already exists.
@@ -595,7 +601,10 @@ export class Client extends Base {
    * console.log("Cluster created:", configHash);
    * ```
    */
-  async createClusterDefinition(newCluster: ClusterPayload): Promise<string> {
+  async createClusterDefinition(
+    newCluster: ClusterPayload,
+    version: string = CONFIG_VERSION,
+  ): Promise<string> {
     if (!this.signer) {
       throw new SignerRequiredError('createClusterDefinition');
     }
@@ -609,7 +618,7 @@ export class Client extends Base {
       ...validatedCluster,
       fork_version: this.fork_version,
       dkg_algorithm: DKG_ALGORITHM,
-      version: CONFIG_VERSION,
+      version,
       uuid: uuidv4(),
       timestamp: new Date().toISOString(),
       threshold: Math.ceil((2 * validatedCluster.operators.length) / 3),

--- a/test/client/methods.spec.ts
+++ b/test/client/methods.spec.ts
@@ -11,7 +11,7 @@ import {
   nullDepositAmountsClusterLockV1X8,
   clusterLockSoloV1X10,
 } from '../fixtures.js';
-import { SDK_VERSION } from '../../src/constants.js';
+import { SDK_VERSION, CONFIG_VERSION } from '../../src/constants.js';
 import { Base } from '../../src/base.js';
 import { hasUniqueDistributedKeys } from '../../src/verification/common.js';
 import { clusterConfigOrDefinitionHash } from '../../src/verification/common.js';
@@ -61,6 +61,27 @@ describe('Cluster Client', () => {
     const configHash =
       await clientInstance.createClusterDefinition(clusterConfigV1X10);
     expect(configHash).toEqual(mockConfigHash);
+  });
+
+  test('createClusterDefinition stamps the requested version (default CONFIG_VERSION)', async () => {
+    const requestMock = jest
+      .fn()
+      .mockReturnValue(Promise.resolve({ config_hash: mockConfigHash }));
+    clientInstance['request'] = requestMock as never;
+
+    // Explicit older version (e.g. while charon prod is pre-v1.11).
+    await clientInstance.createClusterDefinition(clusterConfigV1X10, 'v1.10.0');
+    const explicitBody = JSON.parse(
+      (requestMock.mock.calls[0][1] as { body: string }).body,
+    );
+    expect(explicitBody.version).toEqual('v1.10.0');
+
+    // Omitting the arg defaults to the SDK's CONFIG_VERSION.
+    await clientInstance.createClusterDefinition(clusterConfigV1X10);
+    const defaultBody = JSON.parse(
+      (requestMock.mock.calls[1][1] as { body: string }).body,
+    );
+    expect(defaultBody.version).toEqual(CONFIG_VERSION);
   });
 
   test('acceptClusterDefinition should return cluster definition', async () => {


### PR DESCRIPTION
Adds a second arg to createClusterDefinition, defaulting to CONFIG_VERSION. Lets the launchpad create v1.10.0 definitions while charon production is pre-v1.11 (v1.11.0 definitions require charon >= v1.11.0 to run DKG), and switch back to v1.11.0 without another SDK release once charon v1.11 stable ships. Existing one-arg callers are unchanged (still get CONFIG_VERSION).

Branched off Hanan/safe-eoa-exit-withdrawal, so this release also carries the Safe exit/withdrawal support and the SignerRequiredError guards.